### PR TITLE
Add custom auth pages with Supabase adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Next create a `.env.local` file with the following variables:
 ```bash
 NEXT_PUBLIC_SUPABASE_URL=<your Supabase url>
 NEXT_PUBLIC_SUPABASE_ANON_KEY=<your Supabase anon key>
+SUPABASE_SERVICE_ROLE_KEY=<your Supabase service role key>
 GITHUB_ID=<GitHub OAuth app id>
 GITHUB_SECRET=<GitHub OAuth secret>
 NEXTAUTH_SECRET=<random string>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "addiapp",
       "version": "0.1.0",
       "dependencies": {
+        "@auth/supabase-adapter": "^1.10.0",
         "@supabase/supabase-js": "^2.53.0",
         "next": "15.4.4",
         "next-auth": "^4.24.11",
@@ -51,6 +52,165 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@auth/core": {
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.34.2.tgz",
+      "integrity": "sha512-KywHKRgLiF3l7PLyL73fjLSIBe1YNcA6sMeew4yMP6cfCWGXZrkkXd32AjRi1hlJ9nvovUBGZHvbn+LijO6ZeQ==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@panva/hkdf": "^1.1.1",
+        "@types/cookie": "0.6.0",
+        "cookie": "0.6.0",
+        "jose": "^5.1.3",
+        "oauth4webapi": "^2.10.4",
+        "preact": "10.11.3",
+        "preact-render-to-string": "5.2.3"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^6.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@auth/core/node_modules/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@auth/core/node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@auth/core/node_modules/preact": {
+      "version": "10.11.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
+      "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/@auth/core/node_modules/preact-render-to-string": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.3.tgz",
+      "integrity": "sha512-aPDxUn5o3GhWdtJtW0svRC2SS/l8D9MAgo2+AWml+BhDImb27ALf04Q2d+AHqUUOc6RdSXFIBVa2gxzgMKgtZA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "pretty-format": "^3.8.0"
+      },
+      "peerDependencies": {
+        "preact": ">=10"
+      }
+    },
+    "node_modules/@auth/supabase-adapter": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@auth/supabase-adapter/-/supabase-adapter-1.10.0.tgz",
+      "integrity": "sha512-Gix/dTRBjuj3/zqbMKVhu8z8j93QI3baZS0Fs5VIqpBoeSIxIAyXKJnZBy24B7Uazecp1VUIolbyt5yrR18gFw==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.40.0"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.43.1"
+      }
+    },
+    "node_modules/@auth/supabase-adapter/node_modules/@auth/core": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.40.0.tgz",
+      "integrity": "sha512-n53uJE0RH5SqZ7N1xZoMKekbHfQgjd0sAEyUbE+IYJnmuQkbvuZnXItCU7d+i7Fj8VGOgqvNO7Mw4YfBTlZeQw==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^6.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@auth/supabase-adapter/node_modules/jose": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.12.tgz",
+      "integrity": "sha512-T8xypXs8CpmiIi78k0E+Lk7T2zlK4zDyg+o1CZ4AkOHgDg98ogdP2BeZ61lTFKFyoEwJ9RgAgN+SdM3iPgNonQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@auth/supabase-adapter/node_modules/oauth4webapi": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.6.0.tgz",
+      "integrity": "sha512-OwXPTXjKPOldTpAa19oksrX9TYHA0rt+VcUFTkJ7QKwgmevPpNm9Cn5vFZUtIo96FiU6AfPuUUGzoXqgOzibWg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@auth/supabase-adapter/node_modules/preact": {
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/@auth/supabase-adapter/node_modules/preact-render-to-string": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": ">=10"
       }
     },
     "node_modules/@babel/runtime": {
@@ -1370,6 +1530,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -4923,6 +5091,17 @@
       "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
       "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
       "license": "MIT"
+    },
+    "node_modules/oauth4webapi": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-2.17.0.tgz",
+      "integrity": "sha512-lbC0Z7uzAFNFyzEYRIC+pkSVvDHJTbEW+dYlSBAlCYDe6RxUkJ26bClhk8ocBZip1wfI9uKTe0fm4Ib4RHn6uQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.53.0",
+    "@auth/supabase-adapter": "^1.10.0",
     "next": "15.4.4",
     "next-auth": "^4.24.11",
     "react": "19.1.0",

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,14 +1,39 @@
 import NextAuth from 'next-auth'
 import GitHub from 'next-auth/providers/github'
-// You can add Email, Credentials, etc.
+import Credentials from 'next-auth/providers/credentials'
+import { SupabaseAdapter } from '@auth/supabase-adapter'
+import { supabaseServer } from '@/lib/supabaseServer'
 
 const handler = NextAuth({
+  adapter: SupabaseAdapter({
+    url: process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    secret: process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  }),
   providers: [
     GitHub({
       clientId: process.env.GITHUB_ID!,
       clientSecret: process.env.GITHUB_SECRET!,
     }),
+    Credentials({
+      name: 'Credentials',
+      credentials: {
+        email: { label: 'Email', type: 'email' },
+        password: { label: 'Password', type: 'password' },
+      },
+      async authorize(credentials) {
+        if (!credentials) return null
+        const { data, error } = await supabaseServer.auth.signInWithPassword({
+          email: credentials.email,
+          password: credentials.password,
+        })
+        if (error || !data.user) return null
+        return { id: data.user.id, email: data.user.email }
+      },
+    }),
   ],
+  pages: {
+    signIn: '/signin',
+  },
   secret: process.env.NEXTAUTH_SECRET,
 })
 

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { useState } from 'react'
+import { signIn } from 'next-auth/react'
+import Link from 'next/link'
+import { supabase } from '@/lib/supabase'
+
+export default function RegisterPage() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const { error } = await supabase.auth.signUp({ email, password })
+    if (error) {
+      setError(error.message)
+      return
+    }
+    await signIn('credentials', { email, password, callbackUrl: '/' })
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-100">
+      <div className="bg-white p-6 rounded shadow w-full max-w-sm">
+        <h1 className="text-xl font-bold mb-4 text-center">Register</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            className="w-full p-2 border rounded"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="Email"
+          />
+          <input
+            className="w-full p-2 border rounded"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Password"
+          />
+          {error && <p className="text-red-600">{error}</p>}
+          <button type="submit" className="w-full bg-blue-600 text-white py-2 rounded">
+            Register
+          </button>
+        </form>
+        <p className="text-center text-sm mt-4">
+          Already have an account? <Link href="/signin" className="text-blue-600">Sign in</Link>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState } from 'react'
-import { signIn } from 'next-auth/react'
 import Link from 'next/link'
 import { supabase } from '@/lib/supabase'
 
@@ -9,15 +8,20 @@ export default function RegisterPage() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+    setError(null)
+    setSuccess(null)
     const { error } = await supabase.auth.signUp({ email, password })
     if (error) {
       setError(error.message)
       return
     }
-    await signIn('credentials', { email, password, callbackUrl: '/' })
+    setSuccess('Registration successful! Please check your email to confirm your account.')
+    setEmail('')
+    setPassword('')
   }
 
   return (
@@ -31,6 +35,7 @@ export default function RegisterPage() {
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             placeholder="Email"
+            required
           />
           <input
             className="w-full p-2 border rounded"
@@ -38,8 +43,10 @@ export default function RegisterPage() {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             placeholder="Password"
+            required
           />
           {error && <p className="text-red-600">{error}</p>}
+          {success && <p className="text-green-600">{success}</p>}
           <button type="submit" className="w-full bg-blue-600 text-white py-2 rounded">
             Register
           </button>

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useState } from 'react'
-import { signIn } from 'next-auth/react'
 import Link from 'next/link'
+import { supabase } from '@/lib/supabase'
 
 export default function SignInPage() {
   const [email, setEmail] = useState('')
@@ -11,12 +11,9 @@ export default function SignInPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    const res = await signIn('credentials', {
-      email,
-      password,
-      redirect: false,
-    })
-    if (res?.error) {
+    setError(null)
+    const { error } = await supabase.auth.signInWithPassword({ email, password })
+    if (error) {
       setError('Invalid credentials')
     } else {
       window.location.href = '/'
@@ -34,6 +31,7 @@ export default function SignInPage() {
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             placeholder="Email"
+            required
           />
           <input
             className="w-full p-2 border rounded"
@@ -41,17 +39,13 @@ export default function SignInPage() {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             placeholder="Password"
+            required
           />
           {error && <p className="text-red-600">{error}</p>}
           <button type="submit" className="w-full bg-blue-600 text-white py-2 rounded">
             Sign In
           </button>
         </form>
-        <div className="mt-4 text-center">
-          <button onClick={() => signIn('github')} className="text-sm text-gray-600 underline">
-            Sign in with GitHub
-          </button>
-        </div>
         <p className="text-center text-sm mt-4">
           Don&apos;t have an account? <Link href="/register" className="text-blue-600">Register</Link>
         </p>

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { useState } from 'react'
+import { signIn } from 'next-auth/react'
+import Link from 'next/link'
+
+export default function SignInPage() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const res = await signIn('credentials', {
+      email,
+      password,
+      redirect: false,
+    })
+    if (res?.error) {
+      setError('Invalid credentials')
+    } else {
+      window.location.href = '/'
+    }
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-100">
+      <div className="bg-white p-6 rounded shadow w-full max-w-sm">
+        <h1 className="text-xl font-bold mb-4 text-center">Sign In</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            className="w-full p-2 border rounded"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="Email"
+          />
+          <input
+            className="w-full p-2 border rounded"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Password"
+          />
+          {error && <p className="text-red-600">{error}</p>}
+          <button type="submit" className="w-full bg-blue-600 text-white py-2 rounded">
+            Sign In
+          </button>
+        </form>
+        <div className="mt-4 text-center">
+          <button onClick={() => signIn('github')} className="text-sm text-gray-600 underline">
+            Sign in with GitHub
+          </button>
+        </div>
+        <p className="text-center text-sm mt-4">
+          Don&apos;t have an account? <Link href="/register" className="text-blue-600">Register</Link>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/supabaseServer.ts
+++ b/src/lib/supabaseServer.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+export const supabaseServer = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+)


### PR DESCRIPTION
## Summary
- create custom signin and register pages with Tailwind
- integrate Supabase adapter for Auth.js
- connect credential login to Supabase
- document new env variable

## Testing
- `./scripts/setup.sh`
- `npm run lint` *(fails: Bus error)*
- `npm run build` *(fails: Bus error)*

------
https://chatgpt.com/codex/tasks/task_e_68888d43256c83289e65fd5124bada96