### PR TITLE
Improve auth UX

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,14 @@
+import { NextResponse, NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  const token = request.cookies.get('sb-access-token')?.value
+  if (!token && request.nextUrl.pathname === '/') {
+    const url = new URL('/signin', request.url)
+    return NextResponse.redirect(url)
+  }
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/'],
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
 import type { User } from '@supabase/supabase-js'
 import { supabase } from '@/lib/supabase'
 import { AddiApp } from '@/types/addiapp'
@@ -11,6 +12,7 @@ export default function HomePage() {
   const [addiapps, setAddiapps] = useState<AddiApp[]>([])
   const [title, setTitle] = useState('')
   const [error, setError] = useState<string | null>(null)
+  const router = useRouter()
 
   useEffect(() => {
     supabase.auth.getUser().then(({ data }) => {
@@ -31,9 +33,9 @@ export default function HomePage() {
     if (!loading && user) {
       fetchAddiapps()
     } else if (!loading && !user) {
-      window.location.href = '/signin'
+      router.push('/signin')
     }
-  }, [loading, user])
+  }, [loading, router, user])
 
   const fetchAddiapps = async () => {
     try {

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -8,23 +8,38 @@ export default function RegisterPage() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const validate = () => {
+    if (!email || !password) {
+      setError('Email and password are required')
+      return false
+    }
+    if (password.length < 6) {
+      setError('Password must be at least 6 characters')
+      return false
+    }
+    return true
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    const { error } = await supabase.auth.signUp({ email, password })
+    if (!validate()) return
+    setLoading(true)
+    const { error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: { emailRedirectTo: window.location.origin },
+    })
+    setLoading(false)
     if (error) {
       setError(error.message)
       return
     }
-    const { error: signInError } = await supabase.auth.signInWithPassword({
-      email,
-      password,
-    })
-    if (signInError) {
-      setError(signInError.message)
-      return
-    }
-    window.location.href = '/'
+    setSuccess('Check your email for a confirmation link.')
+    setEmail('')
+    setPassword('')
   }
 
   return (
@@ -47,8 +62,13 @@ export default function RegisterPage() {
             placeholder="Password"
           />
           {error && <p className="text-red-600">{error}</p>}
-          <button type="submit" className="w-full bg-blue-600 text-white py-2 rounded">
-            Register
+          {success && <p className="text-green-600">{success}</p>}
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full bg-blue-600 disabled:bg-gray-400 text-white py-2 rounded"
+          >
+            {loading ? 'Registering...' : 'Register'}
           </button>
         </form>
         <p className="text-center text-sm mt-4">

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -2,23 +2,41 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import { supabase } from '@/lib/supabase'
 
 export default function SignInPage() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const router = useRouter()
+
+  const validate = () => {
+    if (!email || !password) {
+      setError('Email and password are required')
+      return false
+    }
+    if (password.length < 6) {
+      setError('Password must be at least 6 characters')
+      return false
+    }
+    return true
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+    if (!validate()) return
+    setLoading(true)
     const { error } = await supabase.auth.signInWithPassword({
       email,
       password,
     })
+    setLoading(false)
     if (error) {
-      setError('Invalid credentials')
+      setError(error.message)
     } else {
-      window.location.href = '/'
+      router.push('/')
     }
   }
 
@@ -42,8 +60,12 @@ export default function SignInPage() {
             placeholder="Password"
           />
           {error && <p className="text-red-600">{error}</p>}
-          <button type="submit" className="w-full bg-blue-600 text-white py-2 rounded">
-            Sign In
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full bg-blue-600 disabled:bg-gray-400 text-white py-2 rounded"
+          >
+            {loading ? 'Signing In...' : 'Sign In'}
           </button>
         </form>
         <p className="text-center text-sm mt-4">

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -32,8 +32,8 @@ export default function SignInPage() {
       email,
       password,
     })
-    setLoading(false)
     if (error) {
+      setLoading(false)
       setError(error.message)
     } else {
       router.push('/')


### PR DESCRIPTION
## Summary
- add email/password validation and loading state for sign in
- improve registration with validation, email confirmation, and loading state
- use Next.js router for redirects
- guard home route with middleware

## Testing
- `./scripts/setup.sh`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6888d2a2862c8328b76ff1fa339d0c64