### PR TITLE
Close #29 - Play mode: Home screen

### DIFF
--- a/.changes/unreleased/29-play-mode-home-screen.md
+++ b/.changes/unreleased/29-play-mode-home-screen.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Changed -->
+- Play mode: Home screen ([#29](https://github.com/neturely/addiapp/issues/29))

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -2,34 +2,40 @@ import { Link } from 'react-router-dom'
 import { useAuth } from '@/auth/useAuth'
 import { Mascot } from '@/components/Mascot'
 
+/**
+ * Play-mode home screen (issue #29, PROJECT_SPEC §5.1). The mascot-guided entry
+ * point: a single "Let's go" leading into the choice screen (#30), plus a
+ * secondary "Add a task" (#35). Shares the mascot / coral / spacing language of
+ * the choice, task-presented, in-progress and completion screens.
+ */
 export function Home() {
   const { user, logout } = useAuth()
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-5 p-8 text-center">
+    <main className="relative flex min-h-screen flex-col items-center justify-center gap-6 p-8 text-center">
       <Mascot mood="happy" />
-      <h1 className="text-3xl font-bold text-gray-800">Ready to do something great today?</h1>
-      <p className="text-gray-500">
-        Signed in as <span className="font-semibold">{user?.displayName ?? user?.email}</span>
-      </p>
-      <Link
-        to="/play"
-        className="rounded-xl bg-[#D85A30] px-8 py-3 text-lg font-semibold text-white transition hover:bg-[#c24d27]"
-      >
-        Let&apos;s go
-      </Link>
-      <Link to="/tasks/new" className="text-sm font-medium text-[#a8431f] underline hover:text-[#7f3217]">
-        Add a task
-      </Link>
-      <p className="text-xs text-gray-400">
-        (Full Play-mode home is issue #29 — this is a temporary entry.)
-      </p>
-      <button
-        onClick={() => void logout()}
-        className="text-sm text-gray-400 underline hover:text-gray-600"
-      >
-        Log out
-      </button>
+      <h1 className="max-w-md text-3xl font-bold text-gray-800">
+        Ready to do something great today?
+      </h1>
+
+      <div className="mt-2 flex flex-col items-center gap-3">
+        <Link
+          to="/play"
+          className="rounded-xl bg-[#D85A30] px-10 py-3 text-lg font-semibold text-white transition hover:bg-[#c24d27]"
+        >
+          Let&apos;s go
+        </Link>
+        <Link to="/tasks/new" className="text-sm text-gray-500 underline hover:text-gray-700">
+          Add a task
+        </Link>
+      </div>
+
+      <footer className="absolute bottom-6 flex flex-col items-center gap-1 text-xs text-gray-400">
+        <span>Signed in as {user?.displayName ?? user?.email}</span>
+        <button onClick={() => void logout()} className="underline hover:text-gray-600">
+          Log out
+        </button>
+      </footer>
     </main>
   )
 }


### PR DESCRIPTION
## Summary
Play-mode home screen — the real mascot-guided entry, replacing the placeholder.

## Screen
- Mascot (same placeholder character used across #30–#34) + "Ready to do something great today?"
- Single primary **Let's go** CTA → choice screen (#30).
- Secondary **Add a task** link → the add-task form (#35).
- Logout moved to a discreet footer (was a prominent "Signed in as… / temporary entry" placeholder).

Shares the mascot / coral / spacing language of the choice, task-presented, in-progress and completion screens for visual consistency. Responsive (centered flex column, `max-w` heading).

## Scope / notes
- Presentational change to `Home.tsx` only — the `/` route, choice screen, and add-task form already exist and are wired.
- The mockup's "secondary link to Dashboard" is realised as "Add a task" for now (per owner) since the Dashboard (#36) isn't built yet; easy to add a Dashboard entry when it lands.
- Placeholder mascot and non-final palette are expected (§10, still open).

## Verification
Client typecheck, `vite build`, eslint pass. No new data/endpoint surface; every navigation target (`/play`, `/tasks/new`) and the logout wiring are already verified.

## Changes
- Play-mode home screen (#29)

Closes #29