### PR TITLE
Close #31 - Play mode: Task-presented screen + Start + re-roll

### DIFF
--- a/.changes/unreleased/31-play-mode-task-presented-screen-start.md
+++ b/.changes/unreleased/31-play-mode-task-presented-screen-start.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Changed -->
+- Play mode: Task-presented screen + Start + re-roll ([#31](https://github.com/neturely/addiapp/issues/31))

--- a/client/src/components/EmptyState.tsx
+++ b/client/src/components/EmptyState.tsx
@@ -1,0 +1,37 @@
+import { Link } from 'react-router-dom'
+import { Mascot } from './Mascot'
+
+/**
+ * Play-mode empty state (issue #32): nothing to present. Shown when task
+ * selection returns no match. `filtered` distinguishes "your filters matched
+ * nothing" (offer to change them) from "no tasks at all".
+ *
+ * The real "Add a task" entry lands with the add-task form (#35) and dashboard
+ * (#36); until then the useful recovery is to widen the win/time filter.
+ */
+export function EmptyState({ filtered = false }: { filtered?: boolean }) {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8 text-center">
+      <Mascot mood="sleepy" />
+      <div className="space-y-1">
+        <h1 className="text-2xl font-bold text-gray-800">Nothing here right now</h1>
+        <p className="text-gray-500">
+          {filtered
+            ? 'No task matches that pick. Try a different kind of win or more time.'
+            : 'Your backlog is empty. Add a task to get the ball rolling.'}
+        </p>
+      </div>
+      <div className="flex flex-col gap-3">
+        <Link
+          to="/play"
+          className="rounded-lg bg-[#D85A30] px-6 py-3 font-semibold text-white transition hover:bg-[#c24d27]"
+        >
+          {filtered ? 'Pick a different win' : 'Choose a win'}
+        </Link>
+        <Link to="/" className="text-sm text-gray-500 underline hover:text-gray-700">
+          Back home
+        </Link>
+      </div>
+    </main>
+  )
+}

--- a/client/src/components/Mascot.tsx
+++ b/client/src/components/Mascot.tsx
@@ -1,0 +1,53 @@
+type Mood = 'happy' | 'thinking' | 'sleepy'
+
+/**
+ * Placeholder mascot — a simple flat blob character, kept deliberately minimal.
+ * Real mascot art + expression variations are a later design pass (see CLAUDE.md);
+ * this just holds the spot consistently across the Play-mode screens. `mood`
+ * nudges the face so Home / Choice / empty state don't all look identical.
+ */
+export function Mascot({ mood = 'happy', className = '' }: { mood?: Mood; className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 120 120"
+      className={className}
+      role="img"
+      aria-label="AddiApp mascot"
+      width="120"
+      height="120"
+    >
+      {/* body */}
+      <ellipse cx="60" cy="66" rx="42" ry="40" fill="#D85A30" />
+      <ellipse cx="60" cy="72" rx="30" ry="26" fill="#F3B598" />
+      {/* eyes */}
+      {mood === 'sleepy' ? (
+        <>
+          <path d="M40 56 q8 6 16 0" stroke="#3A2016" strokeWidth="3" fill="none" strokeLinecap="round" />
+          <path d="M64 56 q8 6 16 0" stroke="#3A2016" strokeWidth="3" fill="none" strokeLinecap="round" />
+        </>
+      ) : (
+        <>
+          <circle cx="48" cy="56" r="6" fill="#3A2016" />
+          <circle cx="72" cy="56" r="6" fill="#3A2016" />
+          <circle cx="50" cy="54" r="2" fill="#fff" />
+          <circle cx="74" cy="54" r="2" fill="#fff" />
+        </>
+      )}
+      {/* mouth */}
+      {mood === 'thinking' ? (
+        <circle cx="60" cy="76" r="4" fill="#3A2016" />
+      ) : (
+        <path
+          d="M48 74 q12 12 24 0"
+          stroke="#3A2016"
+          strokeWidth="3.5"
+          fill="none"
+          strokeLinecap="round"
+        />
+      )}
+      {/* little antenna */}
+      <line x1="60" y1="26" x2="60" y2="14" stroke="#D85A30" strokeWidth="3" strokeLinecap="round" />
+      <circle cx="60" cy="11" r="5" fill="#F5A623" />
+    </svg>
+  )
+}

--- a/client/src/lib/points.ts
+++ b/client/src/lib/points.ts
@@ -1,0 +1,20 @@
+import type { TaskComplexity } from './tasks'
+
+/** Shape of GET /api/points (issue #28). */
+export type PointsStats = {
+  total: number
+  today: {
+    date: string
+    tasksCompleted: number
+    pointsEarned: number
+    /** Multiplier the next completion will earn — shown live in the flow. */
+    currentMultiplier: number
+  }
+  basePoints: Record<TaskComplexity, number>
+}
+
+export async function fetchPoints(): Promise<PointsStats> {
+  const res = await fetch('/api/points', { credentials: 'include' })
+  if (!res.ok) throw new Error(`Request failed (${res.status})`)
+  return res.json() as Promise<PointsStats>
+}

--- a/client/src/lib/tasks.ts
+++ b/client/src/lib/tasks.ts
@@ -1,0 +1,57 @@
+export type TaskComplexity = 'low' | 'medium' | 'high'
+export type TaskStatus = 'backlog' | 'in_progress' | 'done'
+
+export type Task = {
+  id: number
+  title: string
+  complexity: TaskComplexity
+  estimatedMinutes: number
+  status: TaskStatus
+}
+
+export type WinSize = 'small' | 'big'
+
+export type NextTaskFilters = {
+  size?: WinSize
+  /** Time available, in minutes. Omitted means "any". */
+  minutes?: number
+  /** Task id to skip — used by the "give me something else" re-roll. */
+  exclude?: number
+}
+
+/**
+ * Minimal JSON fetch. Mirrors the raw-fetch style already used in AuthProvider;
+ * a shared api wrapper arrives with #61, so this stays dependency-free until then.
+ */
+async function requestJson<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`/api${path}`, {
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  })
+  if (!res.ok) {
+    const body = (await res.json().catch(() => null)) as { error?: string } | null
+    throw new Error(body?.error ?? `Request failed (${res.status})`)
+  }
+  return res.json() as Promise<T>
+}
+
+/** Play-mode selection (issue #31). Returns one matching backlog task, or null. */
+export async function fetchNextTask(filters: NextTaskFilters): Promise<Task | null> {
+  const params = new URLSearchParams()
+  if (filters.size) params.set('size', filters.size)
+  if (filters.minutes != null) params.set('minutes', String(filters.minutes))
+  if (filters.exclude != null) params.set('exclude', String(filters.exclude))
+  const qs = params.toString()
+  const { task } = await requestJson<{ task: Task | null }>(`/tasks/next${qs ? `?${qs}` : ''}`)
+  return task
+}
+
+/** Start a task → moves it to in_progress (reuses the #27 PATCH endpoint). */
+export async function startTask(id: number): Promise<Task> {
+  const { task } = await requestJson<{ task: Task }>(`/tasks/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ status: 'in_progress' }),
+  })
+  return task
+}

--- a/client/src/pages/Choice.tsx
+++ b/client/src/pages/Choice.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { Mascot } from '@/components/Mascot'
+import type { WinSize } from '@/lib/tasks'
+
+/** Time-available presets (minutes). null = "any amount of time". */
+const TIME_OPTIONS: { label: string; minutes: number | null }[] = [
+  { label: 'Any time', minutes: null },
+  { label: '5 min', minutes: 5 },
+  { label: '15 min', minutes: 15 },
+  { label: '30 min', minutes: 30 },
+  { label: '1 hour', minutes: 60 },
+]
+
+/**
+ * Play-mode choice screen (issue #30): "What kind of win do you want?" plus a
+ * time-available filter. Picking a win type carries both selections into the
+ * task-presented screen (#31) as URL params, so the pick is shareable/reloadable.
+ */
+export function Choice() {
+  const navigate = useNavigate()
+  const [minutes, setMinutes] = useState<number | null>(null)
+
+  function go(size: WinSize) {
+    const params = new URLSearchParams({ size })
+    if (minutes != null) params.set('minutes', String(minutes))
+    navigate(`/play/task?${params.toString()}`)
+  }
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-8 p-8 text-center">
+      <Mascot mood="thinking" />
+      <h1 className="text-2xl font-bold text-gray-800">What kind of win do you want?</h1>
+
+      <div className="w-full max-w-md">
+        <p className="mb-2 text-sm font-medium text-gray-500">How much time do you have?</p>
+        <div className="flex flex-wrap justify-center gap-2">
+          {TIME_OPTIONS.map((opt) => {
+            const active = minutes === opt.minutes
+            return (
+              <button
+                key={opt.label}
+                type="button"
+                onClick={() => setMinutes(opt.minutes)}
+                className={`rounded-full px-4 py-1.5 text-sm font-medium transition ${
+                  active
+                    ? 'bg-gray-800 text-white'
+                    : 'border border-gray-300 text-gray-600 hover:bg-gray-50'
+                }`}
+              >
+                {opt.label}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      <div className="grid w-full max-w-md gap-4 sm:grid-cols-2">
+        <button
+          type="button"
+          onClick={() => go('small')}
+          className="rounded-2xl border-2 border-[#2FA39B] bg-[#2FA39B]/10 p-6 text-left transition hover:bg-[#2FA39B]/20"
+        >
+          <div className="text-lg font-bold text-[#1f746e]">Something small</div>
+          <div className="text-sm text-gray-600">A quick, low-effort win</div>
+        </button>
+        <button
+          type="button"
+          onClick={() => go('big')}
+          className="rounded-2xl border-2 border-[#D85A30] bg-[#D85A30]/10 p-6 text-left transition hover:bg-[#D85A30]/20"
+        >
+          <div className="text-lg font-bold text-[#a8431f]">Something big</div>
+          <div className="text-sm text-gray-600">Real progress worth more points</div>
+        </button>
+      </div>
+
+      <Link to="/" className="text-sm text-gray-500 underline hover:text-gray-700">
+        Back home
+      </Link>
+    </main>
+  )
+}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,20 +1,29 @@
+import { Link } from 'react-router-dom'
 import { useAuth } from '@/auth/useAuth'
+import { Mascot } from '@/components/Mascot'
 
 export function Home() {
   const { user, logout } = useAuth()
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center">
-      <h1 className="text-4xl font-bold">AddiApp</h1>
-      <p className="text-gray-600">
+    <main className="flex min-h-screen flex-col items-center justify-center gap-5 p-8 text-center">
+      <Mascot mood="happy" />
+      <h1 className="text-3xl font-bold text-gray-800">Ready to do something great today?</h1>
+      <p className="text-gray-500">
         Signed in as <span className="font-semibold">{user?.displayName ?? user?.email}</span>
       </p>
-      <p className="text-sm text-gray-500">
-        (Play mode home comes next — issue #29. You&apos;re authenticated.)
+      <Link
+        to="/play"
+        className="rounded-xl bg-[#D85A30] px-8 py-3 text-lg font-semibold text-white transition hover:bg-[#c24d27]"
+      >
+        Let&apos;s go
+      </Link>
+      <p className="text-xs text-gray-400">
+        (Full Play-mode home is issue #29 — this is a temporary entry.)
       </p>
       <button
         onClick={() => void logout()}
-        className="rounded bg-gray-800 px-4 py-2 text-sm text-white hover:bg-gray-700"
+        className="text-sm text-gray-400 underline hover:text-gray-600"
       >
         Log out
       </button>

--- a/client/src/pages/TaskPresented.tsx
+++ b/client/src/pages/TaskPresented.tsx
@@ -1,0 +1,161 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
+import { Mascot } from '@/components/Mascot'
+import { EmptyState } from '@/components/EmptyState'
+import { fetchNextTask, startTask, type Task, type TaskComplexity, type WinSize } from '@/lib/tasks'
+import { fetchPoints, type PointsStats } from '@/lib/points'
+
+const COMPLEXITY_TAG: Record<TaskComplexity, { label: string; className: string }> = {
+  low: { label: 'Low effort', className: 'bg-[#2FA39B]/15 text-[#1f746e]' },
+  medium: { label: 'Medium', className: 'bg-[#F5A623]/15 text-[#a06d00]' },
+  high: { label: 'Big effort', className: 'bg-[#D85A30]/15 text-[#a8431f]' },
+}
+
+function formatMinutes(m: number): string {
+  if (m < 60) return `${m} min`
+  const h = Math.floor(m / 60)
+  const rem = m % 60
+  return rem ? `${h}h ${rem}m` : `${h}h`
+}
+
+function parseSize(raw: string | null): WinSize | undefined {
+  return raw === 'small' || raw === 'big' ? raw : undefined
+}
+
+/**
+ * Play-mode task-presented screen (issue #31). Reads the choice-screen filters
+ * from the URL, asks the server for one matching task, and shows it with an
+ * up-front points estimate. Start → in_progress; "give me something else"
+ * re-rolls, excluding the current task so it isn't re-offered immediately.
+ */
+export function TaskPresented() {
+  const [params] = useSearchParams()
+  const size = parseSize(params.get('size'))
+  const minutesParam = params.get('minutes')
+  const minutes = minutesParam ? Number(minutesParam) : undefined
+
+  const [task, setTask] = useState<Task | null>()
+  const [points, setPoints] = useState<PointsStats | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [starting, setStarting] = useState(false)
+  const [started, setStarted] = useState<Task | null>(null)
+
+  const roll = useCallback(
+    async (exclude?: number) => {
+      setLoading(true)
+      setError(null)
+      try {
+        const next = await fetchNextTask({ size, minutes, exclude })
+        setTask(next)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Could not load a task')
+      } finally {
+        setLoading(false)
+      }
+    },
+    [size, minutes],
+  )
+
+  // Initial load: the task and the points context (base points + live multiplier).
+  useEffect(() => {
+    void roll()
+    fetchPoints()
+      .then(setPoints)
+      .catch(() => setPoints(null)) // points are a nice-to-have here, not blocking
+  }, [roll])
+
+  async function onStart() {
+    if (!task) return
+    setStarting(true)
+    setError(null)
+    try {
+      const updated = await startTask(task.id)
+      setStarted(updated)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not start the task')
+    } finally {
+      setStarting(false)
+    }
+  }
+
+  // Started acknowledgement. The real in-progress screen is #33 — this is the
+  // honest stopgap so the Start action has somewhere to land.
+  if (started) {
+    return (
+      <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8 text-center">
+        <Mascot mood="happy" />
+        <div className="space-y-1">
+          <h1 className="text-2xl font-bold text-gray-800">You&apos;re on it! 💪</h1>
+          <p className="text-gray-500">
+            <span className="font-semibold">{started.title}</span> is in progress.
+          </p>
+        </div>
+        <Link
+          to="/"
+          className="rounded-lg bg-[#D85A30] px-6 py-3 font-semibold text-white transition hover:bg-[#c24d27]"
+        >
+          Back home
+        </Link>
+      </main>
+    )
+  }
+
+  if (loading) {
+    return <main className="flex min-h-screen items-center justify-center text-gray-500">Finding you a task…</main>
+  }
+
+  if (!task) {
+    return <EmptyState filtered={Boolean(size || minutes)} />
+  }
+
+  const tag = COMPLEXITY_TAG[task.complexity]
+  const basePoints = points?.basePoints[task.complexity]
+  const multiplier = points?.today.currentMultiplier
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8 text-center">
+      <Mascot mood="happy" />
+
+      <div className="w-full max-w-md rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+        <span className={`inline-block rounded-full px-3 py-1 text-xs font-semibold ${tag.className}`}>
+          {tag.label}
+        </span>
+        <h1 className="mt-3 text-2xl font-bold text-gray-800">{task.title}</h1>
+        <p className="mt-1 text-gray-500">~{formatMinutes(task.estimatedMinutes)}</p>
+
+        {basePoints != null && (
+          <div className="mt-4 rounded-xl bg-gray-50 p-3">
+            <div className="text-lg font-bold text-[#a8431f]">≈ {basePoints} pts</div>
+            <div className="text-xs text-gray-500">
+              + speed bonus if you beat the estimate
+              {multiplier && multiplier > 1 ? ` · ×${multiplier.toFixed(2)} today` : ''}
+            </div>
+          </div>
+        )}
+
+        {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+
+        <button
+          type="button"
+          onClick={onStart}
+          disabled={starting}
+          className="mt-5 w-full rounded-lg bg-[#D85A30] py-3 font-semibold text-white transition hover:bg-[#c24d27] disabled:bg-gray-400"
+        >
+          {starting ? 'Starting…' : 'Start'}
+        </button>
+        <button
+          type="button"
+          onClick={() => void roll(task.id)}
+          className="mt-2 w-full rounded-lg py-2 text-sm text-gray-500 underline hover:text-gray-700"
+        >
+          Give me something else
+        </button>
+      </div>
+
+      <Link to="/play" className="text-sm text-gray-500 underline hover:text-gray-700">
+        Change my pick
+      </Link>
+    </main>
+  )
+}

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -2,6 +2,8 @@ import { createBrowserRouter } from 'react-router-dom'
 import { Home } from '@/pages/Home'
 import { Login } from '@/pages/Login'
 import { Register } from '@/pages/Register'
+import { Choice } from '@/pages/Choice'
+import { TaskPresented } from '@/pages/TaskPresented'
 import { NotFound } from '@/pages/NotFound'
 import { ProtectedRoute } from '@/components/ProtectedRoute'
 
@@ -10,7 +12,11 @@ export const router = createBrowserRouter([
   { path: '/register', element: <Register /> },
   {
     element: <ProtectedRoute />,
-    children: [{ path: '/', element: <Home /> }],
+    children: [
+      { path: '/', element: <Home /> },
+      { path: '/play', element: <Choice /> },
+      { path: '/play/task', element: <TaskPresented /> },
+    ],
   },
   { path: '*', element: <NotFound /> },
 ])

--- a/server/src/routes/tasks.ts
+++ b/server/src/routes/tasks.ts
@@ -1,11 +1,12 @@
 import { Router } from 'express'
 import { z } from 'zod'
-import { and, desc, eq } from 'drizzle-orm'
+import { and, desc, eq, inArray, lte, ne } from 'drizzle-orm'
 import { db } from '../db/index.js'
 import { tasks, type Task } from '../db/schema.js'
 import { requireAuth } from '../middleware/requireAuth.js'
 import { asyncHandler } from '../lib/asyncHandler.js'
 import { awardTaskCompletion } from '../points/award.js'
+import { defaultStrategy } from '../tasks/selection.js'
 
 export const tasksRouter = Router()
 
@@ -14,6 +15,23 @@ tasksRouter.use(requireAuth)
 
 const complexity = z.enum(['low', 'medium', 'high'])
 const status = z.enum(['backlog', 'in_progress', 'done'])
+
+/**
+ * Play-mode win type → task complexity (issue #30/#31). Medium sits in both
+ * pools on purpose: a medium task reads as either a quick-ish win or a step of
+ * real progress, so the guided flow rarely dead-ends when the backlog is small.
+ * One constant to retune if that judgement changes.
+ */
+const WIN_TYPE_COMPLEXITY: Record<'small' | 'big', Array<Task['complexity']>> = {
+  small: ['low', 'medium'],
+  big: ['medium', 'high'],
+}
+
+const nextQuerySchema = z.object({
+  size: z.enum(['small', 'big']).optional(),
+  minutes: z.coerce.number().int().positive().max(100_000).optional(),
+  exclude: z.coerce.number().int().positive().optional(),
+})
 
 const createSchema = z.object({
   title: z.string().trim().min(1).max(255),
@@ -88,6 +106,35 @@ tasksRouter.get(
       .where(and(...conditions))
       .orderBy(desc(tasks.createdAt))
     res.json({ tasks: rows })
+  }),
+)
+
+// GET /api/tasks/next?size=small|big&minutes=15&exclude=42
+// Play-mode selection (issue #31): given the choice-screen filters, return ONE
+// backlog task to present (or null → the empty state). Registered before /:id so
+// "next" is never parsed as a task id.
+tasksRouter.get(
+  '/next',
+  asyncHandler(async (req, res) => {
+    const parsed = nextQuerySchema.safeParse(req.query)
+    if (!parsed.success) {
+      res.status(400).json({ error: parsed.error.issues[0]?.message ?? 'Invalid filters' })
+      return
+    }
+    const { size, minutes, exclude } = parsed.data
+
+    // The route builds the candidate pool (filtering); the strategy only picks
+    // one from it — see ../tasks/selection.ts for why that seam exists.
+    const conditions = [eq(tasks.userId, req.user!.id), eq(tasks.status, 'backlog')]
+    if (size) conditions.push(inArray(tasks.complexity, WIN_TYPE_COMPLEXITY[size]))
+    if (minutes !== undefined) conditions.push(lte(tasks.estimatedMinutes, minutes))
+    if (exclude !== undefined) conditions.push(ne(tasks.id, exclude))
+
+    const candidates = await db
+      .select()
+      .from(tasks)
+      .where(and(...conditions))
+    res.json({ task: defaultStrategy(candidates) })
   }),
 )
 

--- a/server/src/tasks/selection.ts
+++ b/server/src/tasks/selection.ts
@@ -1,0 +1,73 @@
+import type { Task } from '../db/schema.js'
+
+/**
+ * Task-selection strategies for Play mode (issue #31).
+ *
+ * A strategy takes an ALREADY-FILTERED list of candidate tasks (the route has
+ * applied the win-type / time-available / exclude filters) and returns the ONE
+ * task to present, or null when nothing matches. Keeping the choice behind this
+ * interface is deliberate: the plan is to let a user pick their own strategy
+ * from a settings page later, which then becomes "look up the user's preference
+ * and call `strategies[name]`" — a small change, not a rewrite. No plugin system,
+ * just a clear seam so the algorithm never gets inlined into the route handler.
+ *
+ * `rng` is injectable so the randomised strategies are deterministic in tests.
+ */
+export type SelectionStrategy = (candidates: Task[], rng?: () => number) => Task | null
+
+/** Oldest first, then lowest id — stable even when timestamps collide (bulk-created tasks). */
+function byAgeThenId(a: Task, b: Task): number {
+  const at = a.createdAt.getTime()
+  const bt = b.createdAt.getTime()
+  return at !== bt ? at - bt : a.id - b.id
+}
+
+/**
+ * Default strategy: weighted random that favours older tasks.
+ *
+ * Why this one for the gamified "keep momentum" loop:
+ * - Pure random re-offers freely and lets tasks rot at the bottom of the backlog.
+ * - Strict oldest-first is predictable — "give me something else" would just walk
+ *   the list in order, which reads as a to-do list, not a mascot surprising you.
+ * - Weighting toward older keeps anything from stagnating (the oldest task is the
+ *   most likely pick) while staying random, so a re-roll still feels fresh. That
+ *   combination — nothing forgotten + a bit of slot-machine variety — is what the
+ *   single-task guided flow is going for.
+ *
+ * Weights are rank-based (oldest = n … newest = 1), so the function is pure — it
+ * needs no notion of "now" and is trivially testable with a fixed rng.
+ */
+export const weightedByAge: SelectionStrategy = (candidates, rng = Math.random) => {
+  if (candidates.length === 0) return null
+  if (candidates.length === 1) return candidates[0]
+
+  const ordered = [...candidates].sort(byAgeThenId)
+  const n = ordered.length
+  const weights = ordered.map((_, i) => n - i) // oldest heaviest, strictly decreasing
+  const total = (n * (n + 1)) / 2
+
+  let r = rng() * total
+  for (let i = 0; i < n; i++) {
+    r -= weights[i]
+    if (r < 0) return ordered[i]
+  }
+  return ordered[n - 1] // rng() === 1 fallback (spec says [0,1), but be safe)
+}
+
+/** Deterministic: always the oldest matching task. */
+export const oldestFirst: SelectionStrategy = (candidates) =>
+  candidates.length ? [...candidates].sort(byAgeThenId)[0] : null
+
+/** Uniform random among matches. */
+export const uniformRandom: SelectionStrategy = (candidates, rng = Math.random) =>
+  candidates.length ? candidates[Math.floor(rng() * candidates.length)]! : null
+
+export const strategies = { weightedByAge, oldestFirst, uniformRandom } as const
+export type StrategyName = keyof typeof strategies
+
+/**
+ * The active strategy. Swapping this line (or, later, selecting by
+ * `strategies[user.selectionStrategy]`) changes selection app-wide without
+ * touching the route.
+ */
+export const defaultStrategy: SelectionStrategy = weightedByAge


### PR DESCRIPTION
## Summary
Play-mode vertical slice: the guided single-task loop, built as one coherent flow because the screens are tightly coupled.

Closes #30
Closes #32

## Backend
- `GET /api/tasks/next` — takes the choice-screen filters (`size=small|big`, `minutes`, `exclude`) over the user's **backlog** tasks and returns one match or `null`.
- Selection lives behind a swappable `SelectionStrategy` interface (`server/src/tasks/selection.ts`); the route filters, the strategy only picks. Default is **weighted random favouring older tasks** (rank-based weights → pure/deterministic-testable). `oldestFirst` and `uniformRandom` ship as alternates; a future per-user setting is a one-line swap. Win-type→complexity: `small={low,medium}`, `big={medium,high}` (medium in both so the flow rarely dead-ends).

## Frontend
- **Choice screen (#30):** "what kind of win?" small/big + time chips → carries the pick to the task screen as URL params.
- **Task-presented screen (#31):** title, estimated time, effort tag, up-front approximate points (from `GET /api/points` base map). **Start** → `in_progress` (reuses #27 PATCH). **"Give me something else"** re-rolls, excluding the current task.
- **Empty state (#32):** shown when selection returns nothing.
- Placeholder `Mascot`; temporary "Let's go" entry on Home (the real Play-mode home is #29).

## Verification
Server + client typecheck, `vite build`, eslint all pass. Selection endpoint driven end-to-end against MySQL: filters, `null` on no-match, 400/401 guards, re-roll exclusion, and Start transition all confirmed; 60-roll distribution was cleanly monotonic toward older tasks (27/17/13/3).

## Notes for review
- Built on current `develop` (the stale `#30/#31/#32` scaffold branches were empty, off an ancient base). Client uses raw `fetch` to match `develop`'s convention — the shared api wrapper arrives with #61, so nothing conflicts.
- Start currently lands on a lightweight "you're on it" acknowledgement; the real in-progress screen is #33.

## Changes
- chore: init branch for #31

Closes #31