### PR TITLE
Close #33 - Task in-progress screen — NEEDS DESIGN

### DIFF
--- a/.changes/unreleased/33-task-in-progress-screen-needs-design.md
+++ b/.changes/unreleased/33-task-in-progress-screen-needs-design.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Changed -->
+- Task in-progress screen — NEEDS DESIGN ([#33](https://github.com/neturely/addiapp/issues/33))

--- a/client/src/lib/tasks.ts
+++ b/client/src/lib/tasks.ts
@@ -7,6 +7,16 @@ export type Task = {
   complexity: TaskComplexity
   estimatedMinutes: number
   status: TaskStatus
+  /** ISO timestamp set when the task moved to in_progress (issue #33 timer). */
+  startedAt?: string | null
+}
+
+/** Points breakdown returned when a task is completed (issue #28). */
+export type AwardResult = {
+  basePoints: number
+  speedBonus: number
+  multiplier: number
+  totalPoints: number
 }
 
 export type WinSize = 'small' | 'big'
@@ -54,4 +64,21 @@ export async function startTask(id: number): Promise<Task> {
     body: JSON.stringify({ status: 'in_progress' }),
   })
   return task
+}
+
+/** Fetch a single owned task (issue #33 in-progress screen). */
+export async function getTask(id: number): Promise<Task> {
+  const { task } = await requestJson<{ task: Task }>(`/tasks/${id}`)
+  return task
+}
+
+/**
+ * Complete a task → done. Awards points on the first completion (issue #28), so
+ * `pointsAwarded` is present the first time and omitted if it was already done.
+ */
+export async function completeTask(id: number): Promise<{ task: Task; pointsAwarded?: AwardResult }> {
+  return requestJson<{ task: Task; pointsAwarded?: AwardResult }>(`/tasks/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ status: 'done' }),
+  })
 }

--- a/client/src/pages/InProgress.tsx
+++ b/client/src/pages/InProgress.tsx
@@ -1,0 +1,217 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { Mascot } from '@/components/Mascot'
+import { completeTask, getTask, type AwardResult, type Task } from '@/lib/tasks'
+import { fetchPoints, type PointsStats } from '@/lib/points'
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0')
+}
+
+/** Elapsed seconds → M:SS, or H:MM:SS past an hour. */
+function formatClock(totalSeconds: number): string {
+  const s = Math.max(0, totalSeconds)
+  const hours = Math.floor(s / 3600)
+  const minutes = Math.floor((s % 3600) / 60)
+  const seconds = s % 60
+  return hours > 0 ? `${hours}:${pad(minutes)}:${pad(seconds)}` : `${minutes}:${pad(seconds)}`
+}
+
+/**
+ * Play-mode task-in-progress screen (issue #33). A live count-up timer derived
+ * from the server's startedAt (so it survives a refresh) plus a speed-bonus meter
+ * against the estimate — making the §7 speed bonus tangible while you work.
+ * Complete → done, which awards points (#28). The real celebration screen is #34;
+ * until then Complete lands on a lightweight acknowledgement here.
+ */
+export function InProgress() {
+  const { id } = useParams()
+  const taskId = Number(id)
+  const navigate = useNavigate()
+
+  const [task, setTask] = useState<Task | null>(null)
+  const [points, setPoints] = useState<PointsStats | null>(null)
+  const [elapsed, setElapsed] = useState(0) // seconds
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [completing, setCompleting] = useState(false)
+  const [awarded, setAwarded] = useState<AwardResult | null>(null)
+  const [done, setDone] = useState(false)
+  const startedAtRef = useRef<number | null>(null)
+
+  // Load the task + points context, and anchor the timer to the server start time.
+  useEffect(() => {
+    if (!Number.isInteger(taskId) || taskId <= 0) {
+      setError('Invalid task')
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    void (async () => {
+      try {
+        const t = await getTask(taskId)
+        if (cancelled) return
+        if (t.status !== 'in_progress') {
+          // Already done, or never started — the in-progress screen doesn't apply.
+          navigate(t.status === 'done' ? '/' : '/play', { replace: true })
+          return
+        }
+        startedAtRef.current = t.startedAt ? Date.parse(t.startedAt) : Date.now()
+        setTask(t)
+        setElapsed(Math.max(0, Math.floor((Date.now() - startedAtRef.current) / 1000)))
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Could not load the task')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    fetchPoints()
+      .then((p) => !cancelled && setPoints(p))
+      .catch(() => undefined) // points are used only for messaging, non-blocking
+    return () => {
+      cancelled = true
+    }
+  }, [taskId, navigate])
+
+  // Tick the timer once per second while working (stops on completion).
+  useEffect(() => {
+    if (!task || done) return
+    const iv = setInterval(() => {
+      if (startedAtRef.current != null) {
+        setElapsed(Math.max(0, Math.floor((Date.now() - startedAtRef.current) / 1000)))
+      }
+    }, 1000)
+    return () => clearInterval(iv)
+  }, [task, done])
+
+  const onComplete = useCallback(async () => {
+    if (!task) return
+    setCompleting(true)
+    setError(null)
+    try {
+      const { pointsAwarded } = await completeTask(task.id)
+      setAwarded(pointsAwarded ?? null)
+      setDone(true)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not complete the task')
+    } finally {
+      setCompleting(false)
+    }
+  }, [task])
+
+  if (loading) {
+    return <main className="flex min-h-screen items-center justify-center text-gray-500">Loading…</main>
+  }
+
+  if (error && !task) {
+    return (
+      <main className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center">
+        <Mascot mood="sleepy" />
+        <p className="text-gray-600">{error}</p>
+        <Link to="/play" className="text-sm text-gray-500 underline hover:text-gray-700">
+          Back to Play
+        </Link>
+      </main>
+    )
+  }
+
+  // Completion acknowledgement — stopgap until the #34 celebration screen exists.
+  if (done) {
+    return (
+      <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8 text-center">
+        <Mascot mood="happy" />
+        <h1 className="text-3xl font-bold text-gray-800">Done! 🎉</h1>
+        {awarded ? (
+          <div className="space-y-1">
+            <div className="text-2xl font-bold text-[#a8431f]">+{awarded.totalPoints} pts</div>
+            <div className="text-sm text-gray-500">
+              {awarded.basePoints} base
+              {awarded.speedBonus > 0 ? ` + ${awarded.speedBonus} speed bonus ⚡` : ''}
+              {awarded.multiplier > 1 ? ` · ×${awarded.multiplier.toFixed(2)} today` : ''}
+            </div>
+          </div>
+        ) : (
+          <p className="text-gray-500">Nice work.</p>
+        )}
+        <div className="flex flex-col gap-3">
+          <Link
+            to="/play"
+            className="rounded-lg bg-[#D85A30] px-6 py-3 font-semibold text-white transition hover:bg-[#c24d27]"
+          >
+            Another task
+          </Link>
+          <Link to="/" className="text-sm text-gray-500 underline hover:text-gray-700">
+            Back home
+          </Link>
+        </div>
+      </main>
+    )
+  }
+
+  if (!task) return null
+
+  const estimateSec = task.estimatedMinutes * 60
+  const meterFrac = estimateSec > 0 ? Math.min(elapsed / estimateSec, 1) : 1
+  const inBonus = elapsed < estimateSec
+  const elapsedMin = Math.floor(elapsed / 60)
+  const basePoints = points?.basePoints[task.complexity]
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8 text-center">
+      <Mascot mood="happy" />
+      <p className="text-sm font-semibold uppercase tracking-wide text-gray-400">Working on it</p>
+
+      <div className="w-full max-w-md rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+        <h1 className="text-xl font-bold text-gray-800">{task.title}</h1>
+
+        <div className="mt-4 font-mono text-5xl font-bold tabular-nums text-gray-900">
+          {formatClock(elapsed)}
+        </div>
+
+        <div className="mt-4">
+          <div className="h-3 w-full overflow-hidden rounded-full bg-gray-100">
+            <div
+              className={`h-full rounded-full transition-[width] duration-500 ${
+                inBonus ? 'bg-[#2FA39B]' : 'bg-[#D85A30]'
+              }`}
+              style={{ width: `${meterFrac * 100}%` }}
+            />
+          </div>
+          <div className="mt-1 text-xs text-gray-500">
+            {elapsedMin} / {task.estimatedMinutes} min
+          </div>
+        </div>
+
+        <p className="mt-4 text-sm font-medium text-gray-600">
+          {inBonus ? (
+            <>
+              ⚡ Finish within{' '}
+              <span className="font-bold text-[#1f746e]">{formatClock(estimateSec - elapsed)}</span>{' '}
+              for a speed bonus
+            </>
+          ) : (
+            <>
+              Past the estimate — no speed bonus now
+              {basePoints != null ? `, but it's still worth ${basePoints} pts` : ''}. Finish strong 💪
+            </>
+          )}
+        </p>
+
+        {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+
+        <button
+          type="button"
+          onClick={() => void onComplete()}
+          disabled={completing}
+          className="mt-5 w-full rounded-lg bg-[#D85A30] py-3 font-semibold text-white transition hover:bg-[#c24d27] disabled:bg-gray-400"
+        >
+          {completing ? 'Completing…' : 'Complete'}
+        </button>
+      </div>
+
+      <Link to="/" className="text-sm text-gray-400 underline hover:text-gray-600">
+        Leave it running, go home
+      </Link>
+    </main>
+  )
+}

--- a/client/src/pages/TaskPresented.tsx
+++ b/client/src/pages/TaskPresented.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { Link, useSearchParams } from 'react-router-dom'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { Mascot } from '@/components/Mascot'
 import { EmptyState } from '@/components/EmptyState'
 import { fetchNextTask, startTask, type Task, type TaskComplexity, type WinSize } from '@/lib/tasks'
@@ -39,7 +39,7 @@ export function TaskPresented() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [starting, setStarting] = useState(false)
-  const [started, setStarted] = useState<Task | null>(null)
+  const navigate = useNavigate()
 
   const roll = useCallback(
     async (exclude?: number) => {
@@ -71,34 +71,13 @@ export function TaskPresented() {
     setError(null)
     try {
       const updated = await startTask(task.id)
-      setStarted(updated)
+      // Straight into the in-progress screen (#33) — the timer starts from the
+      // server's startedAt that this PATCH just set.
+      navigate(`/play/progress/${updated.id}`)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Could not start the task')
-    } finally {
       setStarting(false)
     }
-  }
-
-  // Started acknowledgement. The real in-progress screen is #33 — this is the
-  // honest stopgap so the Start action has somewhere to land.
-  if (started) {
-    return (
-      <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8 text-center">
-        <Mascot mood="happy" />
-        <div className="space-y-1">
-          <h1 className="text-2xl font-bold text-gray-800">You&apos;re on it! 💪</h1>
-          <p className="text-gray-500">
-            <span className="font-semibold">{started.title}</span> is in progress.
-          </p>
-        </div>
-        <Link
-          to="/"
-          className="rounded-lg bg-[#D85A30] px-6 py-3 font-semibold text-white transition hover:bg-[#c24d27]"
-        >
-          Back home
-        </Link>
-      </main>
-    )
   }
 
   if (loading) {

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -4,6 +4,7 @@ import { Login } from '@/pages/Login'
 import { Register } from '@/pages/Register'
 import { Choice } from '@/pages/Choice'
 import { TaskPresented } from '@/pages/TaskPresented'
+import { InProgress } from '@/pages/InProgress'
 import { NotFound } from '@/pages/NotFound'
 import { ProtectedRoute } from '@/components/ProtectedRoute'
 
@@ -16,6 +17,7 @@ export const router = createBrowserRouter([
       { path: '/', element: <Home /> },
       { path: '/play', element: <Choice /> },
       { path: '/play/task', element: <TaskPresented /> },
+      { path: '/play/progress/:id', element: <InProgress /> },
     ],
   },
   { path: '*', element: <NotFound /> },


### PR DESCRIPTION
## Summary
Task in-progress screen (#33) — the live "working on it" surface for the guided loop.

Design decision (the issue's open question / PROJECT_SPEC §10 "timer vs plain state"): **live count-up timer + speed-bonus meter**, chosen to make the §7 speed bonus tangible while working.

## What it does
- New screen at `/play/progress/:id`. The timer counts up from the server's `startedAt` (set by the #31 Start PATCH), so it survives a refresh — it's not client-only state.
- A meter shows elapsed vs the estimate; while under the estimate it shows the remaining speed-bonus window (⚡ countdown), and past it switches to an encouraging "no bonus now, still worth N pts" message (never punishing).
- **Complete** → `done`, which awards points (#28) and lands on a lightweight celebration acknowledgement showing the breakdown (base + speed bonus · ×daily multiplier).

## Wiring
- #31 Start now navigates straight into this screen instead of the placeholder ack.
- `lib/tasks`: added `getTask`, `completeTask` (returns `pointsAwarded`), and `Task.startedAt`.

## Scope / notes
- No backend changes — reuses the existing `GET /api/tasks/:id` and `PATCH status` endpoints (#27) and the award logic (#28).
- The full celebration/confetti screen is **#34**; the completion acknowledgement here is the honest stopgap until then.

## Verification
Client typecheck, `vite build`, eslint all pass. The data contract was driven end-to-end against MySQL: Start sets `startedAt`; GET returns it with the estimate; an immediate Complete yields `speedBonus: 5` (fast finish → +10 total, "5 base + 5 speed bonus"). No browser driver available to click the live timer, but elapsed derives from the verified `startedAt`.

## Changes
- Play mode: task in-progress screen with live timer + speed-bonus meter (#33)

Closes #33