### PR TITLE
Close #34 - Task completion / celebration screen — NEEDS DESIGN

### DIFF
--- a/.changes/unreleased/34-task-completion-celebration-screen-needs-design.md
+++ b/.changes/unreleased/34-task-completion-celebration-screen-needs-design.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Changed -->
+- Task completion / celebration screen — NEEDS DESIGN ([#34](https://github.com/neturely/addiapp/issues/34))

--- a/client/src/components/Completion.tsx
+++ b/client/src/components/Completion.tsx
@@ -1,0 +1,78 @@
+import { Link } from 'react-router-dom'
+import { Mascot } from './Mascot'
+import type { WinSize } from '@/lib/tasks'
+
+/** A few static confetti-dot accents — moderate ceremony, no animation library. */
+const CONFETTI = [
+  { color: '#D85A30', top: '14%', left: '16%', pulse: true },
+  { color: '#2FA39B', top: '22%', left: '80%', pulse: false },
+  { color: '#F5A623', top: '38%', left: '10%', pulse: false },
+  { color: '#8B5CF6', top: '12%', left: '58%', pulse: true },
+  { color: '#2FA39B', top: '30%', left: '38%', pulse: false },
+  { color: '#F5A623', top: '18%', left: '34%', pulse: true },
+  { color: '#8B5CF6', top: '40%', left: '72%', pulse: false },
+  { color: '#D85A30', top: '48%', left: '24%', pulse: false },
+]
+
+type CompletionProps = {
+  title: string
+  /** Total points earned for this task (from the #28 award). Omitted if not awarded. */
+  totalPoints?: number
+  /** Daily multiplier applied to this completion (brief context, not a breakdown). */
+  multiplier?: number
+  /** Filters from the just-completed task's selection, reused by "Keep going". */
+  size?: WinSize
+  minutes?: number
+}
+
+/**
+ * Play-mode completion / celebration screen (issue #34). Reached from #33's
+ * Complete action, using the pointsAwarded already returned by that PATCH.
+ * Shows the TOTAL only (the base/speed/multiplier breakdown belongs on the future
+ * dashboard, not here). "Keep going" skips the choice screen and reuses the same
+ * win/time filters for a frictionless next task; it falls back to the choice
+ * screen when no filters are available.
+ */
+export function Completion({ title, totalPoints, multiplier, size, minutes }: CompletionProps) {
+  const params = new URLSearchParams()
+  if (size) params.set('size', size)
+  if (minutes != null) params.set('minutes', String(minutes))
+  const keepGoingHref = params.toString() ? `/play/task?${params.toString()}` : '/play'
+
+  return (
+    <main className="relative flex min-h-screen flex-col items-center justify-center gap-6 overflow-hidden p-8 text-center">
+      {CONFETTI.map((c, i) => (
+        <span
+          key={i}
+          aria-hidden
+          className={`absolute h-2.5 w-2.5 rounded-full ${c.pulse ? 'animate-pulse' : ''}`}
+          style={{ backgroundColor: c.color, top: c.top, left: c.left }}
+        />
+      ))}
+
+      <Mascot mood="happy" />
+      <h1 className="text-3xl font-bold text-gray-800">Nice work!</h1>
+      <p className="text-gray-500">{title}</p>
+
+      {totalPoints != null && (
+        <div className="text-6xl font-extrabold tabular-nums text-[#D85A30]">+{totalPoints}</div>
+      )}
+
+      {multiplier != null && multiplier > 1 && (
+        <p className="text-sm text-gray-400">Current daily bonus: {+multiplier.toFixed(2)}x</p>
+      )}
+
+      <div className="mt-2 flex flex-col gap-3">
+        <Link
+          to={keepGoingHref}
+          className="rounded-xl bg-[#D85A30] px-8 py-3 text-lg font-semibold text-white transition hover:bg-[#c24d27]"
+        >
+          Keep going
+        </Link>
+        <Link to="/" className="text-sm text-gray-500 underline hover:text-gray-700">
+          Back to home
+        </Link>
+      </div>
+    </main>
+  )
+}

--- a/client/src/pages/InProgress.tsx
+++ b/client/src/pages/InProgress.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Link, useNavigate, useParams } from 'react-router-dom'
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { Mascot } from '@/components/Mascot'
+import { Completion } from '@/components/Completion'
 import { completeTask, getTask, type AwardResult, type Task } from '@/lib/tasks'
 import { fetchPoints, type PointsStats } from '@/lib/points'
 
@@ -21,13 +22,21 @@ function formatClock(totalSeconds: number): string {
  * Play-mode task-in-progress screen (issue #33). A live count-up timer derived
  * from the server's startedAt (so it survives a refresh) plus a speed-bonus meter
  * against the estimate — making the §7 speed bonus tangible while you work.
- * Complete → done, which awards points (#28). The real celebration screen is #34;
- * until then Complete lands on a lightweight acknowledgement here.
+ * Complete → done, which awards points (#28) and hands off to the celebration
+ * screen (#34), reusing pointsAwarded and the win/time filters from the URL.
  */
 export function InProgress() {
   const { id } = useParams()
   const taskId = Number(id)
   const navigate = useNavigate()
+
+  // Win/time filters carried from the task-presented screen (#31), so the #34
+  // "Keep going" action can offer another task without re-asking.
+  const [params] = useSearchParams()
+  const sizeParam = params.get('size')
+  const size = sizeParam === 'small' || sizeParam === 'big' ? sizeParam : undefined
+  const minutesParam = params.get('minutes')
+  const minutes = minutesParam ? Number(minutesParam) : undefined
 
   const [task, setTask] = useState<Task | null>(null)
   const [points, setPoints] = useState<PointsStats | null>(null)
@@ -115,36 +124,16 @@ export function InProgress() {
     )
   }
 
-  // Completion acknowledgement — stopgap until the #34 celebration screen exists.
+  // Celebration screen (#34), fed by the pointsAwarded from the Complete PATCH.
   if (done) {
     return (
-      <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8 text-center">
-        <Mascot mood="happy" />
-        <h1 className="text-3xl font-bold text-gray-800">Done! 🎉</h1>
-        {awarded ? (
-          <div className="space-y-1">
-            <div className="text-2xl font-bold text-[#a8431f]">+{awarded.totalPoints} pts</div>
-            <div className="text-sm text-gray-500">
-              {awarded.basePoints} base
-              {awarded.speedBonus > 0 ? ` + ${awarded.speedBonus} speed bonus ⚡` : ''}
-              {awarded.multiplier > 1 ? ` · ×${awarded.multiplier.toFixed(2)} today` : ''}
-            </div>
-          </div>
-        ) : (
-          <p className="text-gray-500">Nice work.</p>
-        )}
-        <div className="flex flex-col gap-3">
-          <Link
-            to="/play"
-            className="rounded-lg bg-[#D85A30] px-6 py-3 font-semibold text-white transition hover:bg-[#c24d27]"
-          >
-            Another task
-          </Link>
-          <Link to="/" className="text-sm text-gray-500 underline hover:text-gray-700">
-            Back home
-          </Link>
-        </div>
-      </main>
+      <Completion
+        title={task?.title ?? 'Task complete'}
+        totalPoints={awarded?.totalPoints}
+        multiplier={awarded?.multiplier}
+        size={size}
+        minutes={minutes}
+      />
     )
   }
 

--- a/client/src/pages/TaskPresented.tsx
+++ b/client/src/pages/TaskPresented.tsx
@@ -72,8 +72,13 @@ export function TaskPresented() {
     try {
       const updated = await startTask(task.id)
       // Straight into the in-progress screen (#33) — the timer starts from the
-      // server's startedAt that this PATCH just set.
-      navigate(`/play/progress/${updated.id}`)
+      // server's startedAt that this PATCH just set. Carry the win/time filters so
+      // the #34 "Keep going" action can reuse them for the next task.
+      const progressParams = new URLSearchParams()
+      if (size) progressParams.set('size', size)
+      if (minutes != null) progressParams.set('minutes', String(minutes))
+      const qs = progressParams.toString()
+      navigate(`/play/progress/${updated.id}${qs ? `?${qs}` : ''}`)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Could not start the task')
       setStarting(false)


### PR DESCRIPTION
## Summary
Completion / celebration screen — the payoff at the end of the guided loop.

Design confirmed with the owner (mockup discussed in chat): moderate ceremony, not a takeover.

## Screen
- Mascot + a few static confetti-dot accents (no animation library).
- "Nice work!" + the completed task's title.
- Points earned this task: the **TOTAL only**, large and in the primary colour (e.g. "+26"). No base/speed/multiplier breakdown — that belongs on the future dashboard completed-tasks view, not here.
- Current daily multiplier as brief secondary context (e.g. "Current daily bonus: 1.3x"), shown only when it's above 1.0.
- Actions: **Keep going** (primary) and **Back to home** (secondary).

## Behaviour
- Reached from #33's Complete action, replacing the previous stopgap acknowledgement.
- Uses the `pointsAwarded` already returned by the `PATCH -> done` response (#28) — no extra fetch.
- **Keep going** skips the choice screen and goes straight to a fresh task-presented screen (#31), reusing the same win/time filters from the just-completed task's selection (frictionless repeat). Falls back to the choice screen when no filters are available.
- **Back to home** returns to Home.
- Filters are threaded as query params through the in-progress route (`/play/progress/:id?size=&minutes=`) so Keep going can reuse them.

## Scope / verification
- Frontend only; no backend or endpoint changes.
- Client typecheck, `vite build`, eslint all pass. Verified against MySQL that the completion numbers are real: `pointsAwarded.totalPoints` and `multiplier` come through and the daily multiplier climbs across completions (e.g. 1.30 → 1.45). No browser driver to click the live screen, but every value it renders is from the verified award response.

This closes out the core Play-mode loop: Home → Choice (#30) → Task presented (#31) → In progress (#33) → Completion (#34) → Keep going ↺.

## Changes
- Play mode: completion / celebration screen (#34)

Closes #34