### PR TITLE
Close #35 - Add-task form

### DIFF
--- a/.changes/unreleased/35-add-task-form.md
+++ b/.changes/unreleased/35-add-task-form.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Added -->
+- Add-task form ([#35](https://github.com/neturely/addiapp/issues/35))

--- a/client/src/components/EmptyState.tsx
+++ b/client/src/components/EmptyState.tsx
@@ -6,8 +6,8 @@ import { Mascot } from './Mascot'
  * selection returns no match. `filtered` distinguishes "your filters matched
  * nothing" (offer to change them) from "no tasks at all".
  *
- * The real "Add a task" entry lands with the add-task form (#35) and dashboard
- * (#36); until then the useful recovery is to widen the win/time filter.
+ * When filtered, the useful recovery is to widen the win/time filter; when the
+ * backlog is genuinely empty, adding a task (#35) is the primary action.
  */
 export function EmptyState({ filtered = false }: { filtered?: boolean }) {
   return (
@@ -23,10 +23,16 @@ export function EmptyState({ filtered = false }: { filtered?: boolean }) {
       </div>
       <div className="flex flex-col gap-3">
         <Link
-          to="/play"
+          to={filtered ? '/play' : '/tasks/new'}
           className="rounded-lg bg-[#D85A30] px-6 py-3 font-semibold text-white transition hover:bg-[#c24d27]"
         >
-          {filtered ? 'Pick a different win' : 'Choose a win'}
+          {filtered ? 'Pick a different win' : 'Add a task'}
+        </Link>
+        <Link
+          to={filtered ? '/tasks/new' : '/play'}
+          className="text-sm text-gray-500 underline hover:text-gray-700"
+        >
+          {filtered ? 'Add a task' : 'Choose a win'}
         </Link>
         <Link to="/" className="text-sm text-gray-500 underline hover:text-gray-700">
           Back home

--- a/client/src/lib/tasks.ts
+++ b/client/src/lib/tasks.ts
@@ -21,6 +21,13 @@ export type AwardResult = {
 
 export type WinSize = 'small' | 'big'
 
+/** Fields for creating a task (issue #35 add-task form). */
+export type NewTaskInput = {
+  title: string
+  complexity: TaskComplexity
+  estimatedMinutes: number
+}
+
 export type NextTaskFilters = {
   size?: WinSize
   /** Time available, in minutes. Omitted means "any". */
@@ -44,6 +51,15 @@ async function requestJson<T>(path: string, init?: RequestInit): Promise<T> {
     throw new Error(body?.error ?? `Request failed (${res.status})`)
   }
   return res.json() as Promise<T>
+}
+
+/** Create a task (issue #35 add-task form → the #27 POST /api/tasks endpoint). */
+export async function createTask(input: NewTaskInput): Promise<Task> {
+  const { task } = await requestJson<{ task: Task }>('/tasks', {
+    method: 'POST',
+    body: JSON.stringify(input),
+  })
+  return task
 }
 
 /** Play-mode selection (issue #31). Returns one matching backlog task, or null. */

--- a/client/src/pages/AddTask.tsx
+++ b/client/src/pages/AddTask.tsx
@@ -1,0 +1,185 @@
+import { useEffect, useState, type FormEvent } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { createTask, type TaskComplexity } from '@/lib/tasks'
+import { fetchPoints } from '@/lib/points'
+
+/** Fallback base points if GET /api/points is unavailable (matches #28 config). */
+const DEFAULT_BASE_POINTS: Record<TaskComplexity, number> = { low: 2, medium: 5, high: 10 }
+
+const COMPLEXITY_ORDER: TaskComplexity[] = ['low', 'medium', 'high']
+const COMPLEXITY_LABEL: Record<TaskComplexity, string> = {
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
+}
+
+// Mirror the server's CRUD validation (#27) so we fail fast client-side.
+const MAX_TITLE = 255
+const MAX_MINUTES = 100_000
+
+/**
+ * Add-task form (issue #35). Creates a task via the #27 POST /api/tasks endpoint.
+ * Fields (title, complexity, estimated minutes) and validation mirror the CRUD
+ * rules. The complexity picker shows base points up front (a decided principle:
+ * points are always visible). Reachable from the empty state and Home.
+ */
+export function AddTask() {
+  const navigate = useNavigate()
+  const [basePoints, setBasePoints] = useState(DEFAULT_BASE_POINTS)
+  const [title, setTitle] = useState('')
+  const [complexity, setComplexity] = useState<TaskComplexity>('medium')
+  const [minutes, setMinutes] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [addedTitle, setAddedTitle] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetchPoints()
+      .then((p) => setBasePoints(p.basePoints))
+      .catch(() => undefined) // fall back to defaults; the picker is still usable
+  }, [])
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault()
+    setError(null)
+
+    const trimmed = title.trim()
+    if (trimmed.length < 1 || trimmed.length > MAX_TITLE) {
+      setError('Give the task a title (up to 255 characters).')
+      return
+    }
+    const mins = Number(minutes)
+    if (!Number.isInteger(mins) || mins < 1 || mins > MAX_MINUTES) {
+      setError('Estimated time must be a whole number of minutes (at least 1).')
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      await createTask({ title: trimmed, complexity, estimatedMinutes: mins })
+      setAddedTitle(trimmed)
+      // Reset for a possible "add another".
+      setTitle('')
+      setComplexity('medium')
+      setMinutes('')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not add the task')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (addedTitle) {
+    return (
+      <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8 text-center">
+        <h1 className="text-2xl font-bold text-gray-800">Task added ✓</h1>
+        <p className="text-gray-500">
+          <span className="font-semibold">{addedTitle}</span> is in your backlog.
+        </p>
+        <div className="flex flex-col gap-3">
+          <button
+            onClick={() => setAddedTitle(null)}
+            className="rounded-lg border border-gray-300 px-6 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          >
+            Add another
+          </button>
+          <Link
+            to="/play"
+            className="rounded-lg bg-[#D85A30] px-6 py-3 font-semibold text-white transition hover:bg-[#c24d27]"
+          >
+            Let&apos;s play
+          </Link>
+          <Link to="/" className="text-sm text-gray-500 underline hover:text-gray-700">
+            Back home
+          </Link>
+        </div>
+      </main>
+    )
+  }
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-gray-50 p-4">
+      <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-sm">
+        <h1 className="mb-5 text-center text-2xl font-bold text-gray-800">Add a task</h1>
+        <form onSubmit={onSubmit} className="space-y-5">
+          <div>
+            <label htmlFor="title" className="mb-1 block text-sm font-medium text-gray-600">
+              What needs doing?
+            </label>
+            <input
+              id="title"
+              type="text"
+              value={title}
+              maxLength={MAX_TITLE}
+              placeholder="e.g. Draft the sprint notes"
+              onChange={(e) => setTitle(e.target.value)}
+              className="w-full rounded-lg border border-gray-300 p-2.5 focus:border-[#D85A30] focus:outline-none"
+            />
+          </div>
+
+          <div>
+            <span className="mb-1 block text-sm font-medium text-gray-600">How much effort?</span>
+            <div className="grid grid-cols-3 gap-2">
+              {COMPLEXITY_ORDER.map((c) => {
+                const active = complexity === c
+                return (
+                  <button
+                    key={c}
+                    type="button"
+                    onClick={() => setComplexity(c)}
+                    className={`rounded-lg border-2 py-2 text-center transition ${
+                      active
+                        ? 'border-[#D85A30] bg-[#D85A30]/10'
+                        : 'border-gray-200 hover:border-gray-300'
+                    }`}
+                  >
+                    <div className="text-sm font-semibold text-gray-800">{COMPLEXITY_LABEL[c]}</div>
+                    <div className="text-xs text-gray-500">{basePoints[c]} pts</div>
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+
+          <div>
+            <label htmlFor="minutes" className="mb-1 block text-sm font-medium text-gray-600">
+              Estimated time (minutes)
+            </label>
+            <input
+              id="minutes"
+              type="number"
+              inputMode="numeric"
+              min={1}
+              max={MAX_MINUTES}
+              value={minutes}
+              placeholder="e.g. 25"
+              onChange={(e) => setMinutes(e.target.value)}
+              className="w-full rounded-lg border border-gray-300 p-2.5 focus:border-[#D85A30] focus:outline-none"
+            />
+            <p className="mt-1 text-xs text-gray-400">
+              Beat your estimate to earn a speed bonus.
+            </p>
+          </div>
+
+          {error && <p className="text-sm text-red-600">{error}</p>}
+
+          <button
+            type="submit"
+            disabled={submitting}
+            className="w-full rounded-lg bg-[#D85A30] py-3 font-semibold text-white transition hover:bg-[#c24d27] disabled:bg-gray-400"
+          >
+            {submitting ? 'Adding…' : 'Add task'}
+          </button>
+        </form>
+        <div className="mt-4 flex justify-between text-sm">
+          <button onClick={() => navigate(-1)} className="text-gray-500 underline hover:text-gray-700">
+            Cancel
+          </button>
+          <Link to="/" className="text-gray-500 underline hover:text-gray-700">
+            Home
+          </Link>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -18,6 +18,9 @@ export function Home() {
       >
         Let&apos;s go
       </Link>
+      <Link to="/tasks/new" className="text-sm font-medium text-[#a8431f] underline hover:text-[#7f3217]">
+        Add a task
+      </Link>
       <p className="text-xs text-gray-400">
         (Full Play-mode home is issue #29 — this is a temporary entry.)
       </p>

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -5,6 +5,7 @@ import { Register } from '@/pages/Register'
 import { Choice } from '@/pages/Choice'
 import { TaskPresented } from '@/pages/TaskPresented'
 import { InProgress } from '@/pages/InProgress'
+import { AddTask } from '@/pages/AddTask'
 import { NotFound } from '@/pages/NotFound'
 import { ProtectedRoute } from '@/components/ProtectedRoute'
 
@@ -18,6 +19,7 @@ export const router = createBrowserRouter([
       { path: '/play', element: <Choice /> },
       { path: '/play/task', element: <TaskPresented /> },
       { path: '/play/progress/:id', element: <InProgress /> },
+      { path: '/tasks/new', element: <AddTask /> },
     ],
   },
   { path: '*', element: <NotFound /> },


### PR DESCRIPTION
## Summary
Add-task form — tasks can finally be created from the UI (previously API-only).

## Screen (`/tasks/new`)
- Title, complexity, and estimated minutes — the exact fields the Task model needs.
- Complexity is a segmented picker (Low / Medium / High) that shows base points up front (2 / 5 / 10), consistent with the "points always visible" principle. Base points come from `GET /api/points` (#28) with a static fallback.
- Estimated-minutes field notes the speed-bonus incentive.
- On success: "Add another" (resets) or straight into Play. Cancel / Home links.

## Validation
Client-side checks mirror the server CRUD rules (#27): title 1–255 chars, complexity from the fixed set, whole minutes ≥ 1. The server still enforces them independently.

## Entry points
- Empty state (#32): "Add a task" becomes the primary action when the backlog is genuinely empty (vs. "pick a different win" when filters just matched nothing).
- Home: a new "Add a task" link alongside "Let's go". (The Dashboard entry lands with #36.)

## Scope / verification
- Frontend only; reuses the existing POST /api/tasks (#27). `lib/tasks`: `createTask` + `NewTaskInput`.
- Client typecheck, `vite build`, eslint pass. Verified end-to-end against MySQL: a valid submit creates a `backlog` task (so Play immediately offers it), and the server rejects empty title / bad complexity / zero / fractional minutes with 400 — matching the client guards.

Note: layout/UX was the only open part (§10); the fields and validation are fully determined by the data model, so this is a clean, conventional form — easy to restyle later.

## Changes
- Add-task form (#35)

Closes #35