### PR TITLE
Close #36 - Dashboard: task list / management view

### DIFF
--- a/.changes/unreleased/36-dashboard-task-list-management-view.md
+++ b/.changes/unreleased/36-dashboard-task-list-management-view.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Changed -->
+- Dashboard: task list / management view ([#36](https://github.com/neturely/addiapp/issues/36))

--- a/client/src/components/TaskForm.tsx
+++ b/client/src/components/TaskForm.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useState, type FormEvent } from 'react'
+import { type TaskComplexity } from '@/lib/tasks'
+import { fetchPoints } from '@/lib/points'
+
+/** Fallback base points if GET /api/points is unavailable (matches #28 config). */
+const DEFAULT_BASE_POINTS: Record<TaskComplexity, number> = { low: 2, medium: 5, high: 10 }
+const COMPLEXITY_ORDER: TaskComplexity[] = ['low', 'medium', 'high']
+const COMPLEXITY_LABEL: Record<TaskComplexity, string> = { low: 'Low', medium: 'Medium', high: 'High' }
+
+// Mirror the server's CRUD validation (#27) so we fail fast client-side.
+const MAX_TITLE = 255
+const MAX_MINUTES = 100_000
+
+export type TaskFormValues = {
+  title: string
+  complexity: TaskComplexity
+  estimatedMinutes: number
+}
+
+type TaskFormProps = {
+  initial?: Partial<TaskFormValues>
+  submitLabel: string
+  submittingLabel: string
+  onSubmit: (values: TaskFormValues) => Promise<void>
+}
+
+/**
+ * Shared task fields form (title, complexity, estimated minutes) used by both the
+ * add-task screen (#35) and the dashboard edit page (#36). Keeping the fields in
+ * one place is deliberate future-proofing: when categories / tags / due dates /
+ * priorities land, they get added here once and appear in both create and edit.
+ */
+export function TaskForm({ initial, submitLabel, submittingLabel, onSubmit }: TaskFormProps) {
+  const [basePoints, setBasePoints] = useState(DEFAULT_BASE_POINTS)
+  const [title, setTitle] = useState(initial?.title ?? '')
+  const [complexity, setComplexity] = useState<TaskComplexity>(initial?.complexity ?? 'medium')
+  const [minutes, setMinutes] = useState(
+    initial?.estimatedMinutes != null ? String(initial.estimatedMinutes) : '',
+  )
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    fetchPoints()
+      .then((p) => setBasePoints(p.basePoints))
+      .catch(() => undefined) // fall back to defaults; the picker is still usable
+  }, [])
+
+  async function handle(e: FormEvent) {
+    e.preventDefault()
+    setError(null)
+
+    const trimmed = title.trim()
+    if (trimmed.length < 1 || trimmed.length > MAX_TITLE) {
+      setError('Give the task a title (up to 255 characters).')
+      return
+    }
+    const mins = Number(minutes)
+    if (!Number.isInteger(mins) || mins < 1 || mins > MAX_MINUTES) {
+      setError('Estimated time must be a whole number of minutes (at least 1).')
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      await onSubmit({ title: trimmed, complexity, estimatedMinutes: mins })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handle} className="space-y-5">
+      <div>
+        <label htmlFor="title" className="mb-1 block text-sm font-medium text-gray-600">
+          What needs doing?
+        </label>
+        <input
+          id="title"
+          type="text"
+          value={title}
+          maxLength={MAX_TITLE}
+          placeholder="e.g. Draft the sprint notes"
+          onChange={(e) => setTitle(e.target.value)}
+          className="w-full rounded-lg border border-gray-300 p-2.5 focus:border-[#D85A30] focus:outline-none"
+        />
+      </div>
+
+      <div>
+        <span className="mb-1 block text-sm font-medium text-gray-600">How much effort?</span>
+        <div className="grid grid-cols-3 gap-2">
+          {COMPLEXITY_ORDER.map((c) => {
+            const active = complexity === c
+            return (
+              <button
+                key={c}
+                type="button"
+                onClick={() => setComplexity(c)}
+                className={`rounded-lg border-2 py-2 text-center transition ${
+                  active ? 'border-[#D85A30] bg-[#D85A30]/10' : 'border-gray-200 hover:border-gray-300'
+                }`}
+              >
+                <div className="text-sm font-semibold text-gray-800">{COMPLEXITY_LABEL[c]}</div>
+                <div className="text-xs text-gray-500">{basePoints[c]} pts</div>
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="minutes" className="mb-1 block text-sm font-medium text-gray-600">
+          Estimated time (minutes)
+        </label>
+        <input
+          id="minutes"
+          type="number"
+          inputMode="numeric"
+          min={1}
+          max={MAX_MINUTES}
+          value={minutes}
+          placeholder="e.g. 25"
+          onChange={(e) => setMinutes(e.target.value)}
+          className="w-full rounded-lg border border-gray-300 p-2.5 focus:border-[#D85A30] focus:outline-none"
+        />
+        <p className="mt-1 text-xs text-gray-400">Beat your estimate to earn a speed bonus.</p>
+      </div>
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+
+      <button
+        type="submit"
+        disabled={submitting}
+        className="w-full rounded-lg bg-[#D85A30] py-3 font-semibold text-white transition hover:bg-[#c24d27] disabled:bg-gray-400"
+      >
+        {submitting ? submittingLabel : submitLabel}
+      </button>
+    </form>
+  )
+}

--- a/client/src/lib/tasks.ts
+++ b/client/src/lib/tasks.ts
@@ -50,6 +50,7 @@ async function requestJson<T>(path: string, init?: RequestInit): Promise<T> {
     const body = (await res.json().catch(() => null)) as { error?: string } | null
     throw new Error(body?.error ?? `Request failed (${res.status})`)
   }
+  if (res.status === 204) return undefined as T
   return res.json() as Promise<T>
 }
 
@@ -60,6 +61,30 @@ export async function createTask(input: NewTaskInput): Promise<Task> {
     body: JSON.stringify(input),
   })
   return task
+}
+
+/** List the user's tasks (issue #36 dashboard). Optionally filter by status. */
+export async function fetchTasks(status?: TaskStatus): Promise<Task[]> {
+  const qs = status ? `?status=${status}` : ''
+  const { tasks } = await requestJson<{ tasks: Task[] }>(`/tasks${qs}`)
+  return tasks
+}
+
+/** Patch a task's editable fields and/or status (issue #36 → #27 PATCH). */
+export async function updateTask(
+  id: number,
+  patch: Partial<NewTaskInput> & { status?: TaskStatus },
+): Promise<Task> {
+  const { task } = await requestJson<{ task: Task }>(`/tasks/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(patch),
+  })
+  return task
+}
+
+/** Delete a task (issue #36 → #27 DELETE, 204). */
+export async function deleteTask(id: number): Promise<void> {
+  await requestJson<void>(`/tasks/${id}`, { method: 'DELETE' })
 }
 
 /** Play-mode selection (issue #31). Returns one matching backlog task, or null. */

--- a/client/src/pages/AddTask.tsx
+++ b/client/src/pages/AddTask.tsx
@@ -1,72 +1,22 @@
-import { useEffect, useState, type FormEvent } from 'react'
+import { useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
-import { createTask, type TaskComplexity } from '@/lib/tasks'
-import { fetchPoints } from '@/lib/points'
-
-/** Fallback base points if GET /api/points is unavailable (matches #28 config). */
-const DEFAULT_BASE_POINTS: Record<TaskComplexity, number> = { low: 2, medium: 5, high: 10 }
-
-const COMPLEXITY_ORDER: TaskComplexity[] = ['low', 'medium', 'high']
-const COMPLEXITY_LABEL: Record<TaskComplexity, string> = {
-  low: 'Low',
-  medium: 'Medium',
-  high: 'High',
-}
-
-// Mirror the server's CRUD validation (#27) so we fail fast client-side.
-const MAX_TITLE = 255
-const MAX_MINUTES = 100_000
+import { createTask } from '@/lib/tasks'
+import { TaskForm, type TaskFormValues } from '@/components/TaskForm'
 
 /**
- * Add-task form (issue #35). Creates a task via the #27 POST /api/tasks endpoint.
- * Fields (title, complexity, estimated minutes) and validation mirror the CRUD
- * rules. The complexity picker shows base points up front (a decided principle:
- * points are always visible). Reachable from the empty state and Home.
+ * Add-task screen (issue #35). Wraps the shared TaskForm (also used by the
+ * dashboard edit page, #36) and creates a task via the #27 POST /api/tasks.
+ * Reachable from the empty state, Home, and the dashboard.
  */
 export function AddTask() {
   const navigate = useNavigate()
-  const [basePoints, setBasePoints] = useState(DEFAULT_BASE_POINTS)
-  const [title, setTitle] = useState('')
-  const [complexity, setComplexity] = useState<TaskComplexity>('medium')
-  const [minutes, setMinutes] = useState('')
-  const [error, setError] = useState<string | null>(null)
-  const [submitting, setSubmitting] = useState(false)
   const [addedTitle, setAddedTitle] = useState<string | null>(null)
+  // Bumped to remount a fresh form for "Add another".
+  const [formKey, setFormKey] = useState(0)
 
-  useEffect(() => {
-    fetchPoints()
-      .then((p) => setBasePoints(p.basePoints))
-      .catch(() => undefined) // fall back to defaults; the picker is still usable
-  }, [])
-
-  async function onSubmit(e: FormEvent) {
-    e.preventDefault()
-    setError(null)
-
-    const trimmed = title.trim()
-    if (trimmed.length < 1 || trimmed.length > MAX_TITLE) {
-      setError('Give the task a title (up to 255 characters).')
-      return
-    }
-    const mins = Number(minutes)
-    if (!Number.isInteger(mins) || mins < 1 || mins > MAX_MINUTES) {
-      setError('Estimated time must be a whole number of minutes (at least 1).')
-      return
-    }
-
-    setSubmitting(true)
-    try {
-      await createTask({ title: trimmed, complexity, estimatedMinutes: mins })
-      setAddedTitle(trimmed)
-      // Reset for a possible "add another".
-      setTitle('')
-      setComplexity('medium')
-      setMinutes('')
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Could not add the task')
-    } finally {
-      setSubmitting(false)
-    }
+  async function onSubmit(values: TaskFormValues) {
+    await createTask(values)
+    setAddedTitle(values.title)
   }
 
   if (addedTitle) {
@@ -78,7 +28,10 @@ export function AddTask() {
         </p>
         <div className="flex flex-col gap-3">
           <button
-            onClick={() => setAddedTitle(null)}
+            onClick={() => {
+              setAddedTitle(null)
+              setFormKey((k) => k + 1)
+            }}
             className="rounded-lg border border-gray-300 px-6 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
           >
             Add another
@@ -101,76 +54,7 @@ export function AddTask() {
     <main className="flex min-h-screen items-center justify-center bg-gray-50 p-4">
       <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-sm">
         <h1 className="mb-5 text-center text-2xl font-bold text-gray-800">Add a task</h1>
-        <form onSubmit={onSubmit} className="space-y-5">
-          <div>
-            <label htmlFor="title" className="mb-1 block text-sm font-medium text-gray-600">
-              What needs doing?
-            </label>
-            <input
-              id="title"
-              type="text"
-              value={title}
-              maxLength={MAX_TITLE}
-              placeholder="e.g. Draft the sprint notes"
-              onChange={(e) => setTitle(e.target.value)}
-              className="w-full rounded-lg border border-gray-300 p-2.5 focus:border-[#D85A30] focus:outline-none"
-            />
-          </div>
-
-          <div>
-            <span className="mb-1 block text-sm font-medium text-gray-600">How much effort?</span>
-            <div className="grid grid-cols-3 gap-2">
-              {COMPLEXITY_ORDER.map((c) => {
-                const active = complexity === c
-                return (
-                  <button
-                    key={c}
-                    type="button"
-                    onClick={() => setComplexity(c)}
-                    className={`rounded-lg border-2 py-2 text-center transition ${
-                      active
-                        ? 'border-[#D85A30] bg-[#D85A30]/10'
-                        : 'border-gray-200 hover:border-gray-300'
-                    }`}
-                  >
-                    <div className="text-sm font-semibold text-gray-800">{COMPLEXITY_LABEL[c]}</div>
-                    <div className="text-xs text-gray-500">{basePoints[c]} pts</div>
-                  </button>
-                )
-              })}
-            </div>
-          </div>
-
-          <div>
-            <label htmlFor="minutes" className="mb-1 block text-sm font-medium text-gray-600">
-              Estimated time (minutes)
-            </label>
-            <input
-              id="minutes"
-              type="number"
-              inputMode="numeric"
-              min={1}
-              max={MAX_MINUTES}
-              value={minutes}
-              placeholder="e.g. 25"
-              onChange={(e) => setMinutes(e.target.value)}
-              className="w-full rounded-lg border border-gray-300 p-2.5 focus:border-[#D85A30] focus:outline-none"
-            />
-            <p className="mt-1 text-xs text-gray-400">
-              Beat your estimate to earn a speed bonus.
-            </p>
-          </div>
-
-          {error && <p className="text-sm text-red-600">{error}</p>}
-
-          <button
-            type="submit"
-            disabled={submitting}
-            className="w-full rounded-lg bg-[#D85A30] py-3 font-semibold text-white transition hover:bg-[#c24d27] disabled:bg-gray-400"
-          >
-            {submitting ? 'Adding…' : 'Add task'}
-          </button>
-        </form>
+        <TaskForm key={formKey} submitLabel="Add task" submittingLabel="Adding…" onSubmit={onSubmit} />
         <div className="mt-4 flex justify-between text-sm">
           <button onClick={() => navigate(-1)} className="text-gray-500 underline hover:text-gray-700">
             Cancel

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,0 +1,400 @@
+import { useEffect, useRef, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import {
+  deleteTask,
+  fetchTasks,
+  startTask,
+  updateTask,
+  type Task,
+  type TaskComplexity,
+  type TaskStatus,
+} from '@/lib/tasks'
+
+type Filter = 'all' | TaskStatus
+
+const FILTERS: { key: Filter; label: string }[] = [
+  { key: 'all', label: 'All' },
+  { key: 'backlog', label: 'Backlog' },
+  { key: 'in_progress', label: 'In progress' },
+  { key: 'done', label: 'Done' },
+]
+
+const COMPLEXITY_TAG: Record<TaskComplexity, { label: string; className: string }> = {
+  low: { label: 'Low', className: 'bg-[#2FA39B]/15 text-[#1f746e]' },
+  medium: { label: 'Medium', className: 'bg-[#F5A623]/15 text-[#a06d00]' },
+  high: { label: 'High', className: 'bg-[#D85A30]/15 text-[#a8431f]' },
+}
+
+const STATUS_BADGE: Record<TaskStatus, { label: string; className: string }> = {
+  backlog: { label: 'Backlog', className: 'bg-gray-100 text-gray-600' },
+  in_progress: { label: 'In progress', className: 'bg-[#F5A623]/15 text-[#a06d00]' },
+  done: { label: 'Done', className: 'bg-[#2FA39B]/15 text-[#1f746e]' },
+}
+
+const MAX_TITLE = 255
+const MAX_MINUTES = 100_000
+const UNDO_MS = 5000
+
+const byIdDesc = (a: Task, b: Task) => b.id - a.id
+
+type EditValues = {
+  title: string
+  complexity: TaskComplexity
+  estimatedMinutes: string
+  status: TaskStatus
+}
+
+/**
+ * Dashboard (issue #36) — the Todoist/Linear-style admin surface. Lists the
+ * user's tasks with status filter tabs; the four column fields are editable
+ * inline; a per-row Edit action opens the full edit page (#36) for future
+ * fields. Start (backlog) / Resume (in-progress) are the manual selection entry
+ * into the guided in-progress screen (#33). Delete uses an undo toast — no
+ * blocking dialog to interrupt inline editing; the API delete is deferred until
+ * the undo window closes.
+ */
+export function Dashboard() {
+  const navigate = useNavigate()
+  const [tasks, setTasks] = useState<Task[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [filter, setFilter] = useState<Filter>('all')
+
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [editValues, setEditValues] = useState<EditValues | null>(null)
+  const [rowError, setRowError] = useState<string | null>(null)
+  const [savingId, setSavingId] = useState<number | null>(null)
+
+  const [pendingTask, setPendingTask] = useState<Task | null>(null)
+  const pendingRef = useRef<{ task: Task; timer: number } | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    fetchTasks()
+      .then((rows) => !cancelled && setTasks([...rows].sort(byIdDesc)))
+      .catch((e) => !cancelled && setError(e instanceof Error ? e.message : 'Could not load tasks'))
+      .finally(() => !cancelled && setLoading(false))
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // Commit any deferred delete to the server; restore the row if it fails.
+  function commitPending() {
+    const p = pendingRef.current
+    if (!p) return
+    clearTimeout(p.timer)
+    pendingRef.current = null
+    setPendingTask(null)
+    deleteTask(p.task.id).catch(() => {
+      setTasks((prev) => [...prev, p.task].sort(byIdDesc))
+      setError('Could not delete that task — it has been restored.')
+    })
+  }
+
+  // Clean up a still-pending delete on unmount (fail-safe: the task survives).
+  useEffect(() => {
+    return () => {
+      if (pendingRef.current) clearTimeout(pendingRef.current.timer)
+    }
+  }, [])
+
+  function onDelete(task: Task) {
+    commitPending() // flush any earlier pending delete first
+    setTasks((prev) => prev.filter((t) => t.id !== task.id))
+    if (editingId === task.id) setEditingId(null)
+    const timer = window.setTimeout(commitPending, UNDO_MS)
+    pendingRef.current = { task, timer }
+    setPendingTask(task)
+  }
+
+  function undoDelete() {
+    const p = pendingRef.current
+    if (!p) return
+    clearTimeout(p.timer)
+    pendingRef.current = null
+    setPendingTask(null)
+    setTasks((prev) => [...prev, p.task].sort(byIdDesc))
+  }
+
+  function startEdit(task: Task) {
+    setRowError(null)
+    setEditingId(task.id)
+    setEditValues({
+      title: task.title,
+      complexity: task.complexity,
+      estimatedMinutes: String(task.estimatedMinutes),
+      status: task.status,
+    })
+  }
+
+  async function saveEdit(task: Task) {
+    if (!editValues) return
+    const title = editValues.title.trim()
+    if (title.length < 1 || title.length > MAX_TITLE) {
+      setRowError('Title is required (up to 255 characters).')
+      return
+    }
+    const mins = Number(editValues.estimatedMinutes)
+    if (!Number.isInteger(mins) || mins < 1 || mins > MAX_MINUTES) {
+      setRowError('Estimated minutes must be a whole number ≥ 1.')
+      return
+    }
+
+    // Only send changed fields — avoids re-triggering status-transition side effects.
+    const patch: Parameters<typeof updateTask>[1] = {}
+    if (title !== task.title) patch.title = title
+    if (editValues.complexity !== task.complexity) patch.complexity = editValues.complexity
+    if (mins !== task.estimatedMinutes) patch.estimatedMinutes = mins
+    if (editValues.status !== task.status) patch.status = editValues.status
+
+    if (Object.keys(patch).length === 0) {
+      setEditingId(null)
+      return
+    }
+
+    setSavingId(task.id)
+    setRowError(null)
+    try {
+      const updated = await updateTask(task.id, patch)
+      setTasks((prev) => prev.map((t) => (t.id === task.id ? updated : t)).sort(byIdDesc))
+      setEditingId(null)
+    } catch (e) {
+      setRowError(e instanceof Error ? e.message : 'Could not save changes.')
+    } finally {
+      setSavingId(null)
+    }
+  }
+
+  async function onStart(task: Task) {
+    try {
+      await startTask(task.id)
+      navigate(`/play/progress/${task.id}`)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not start the task')
+    }
+  }
+
+  const visible = (filter === 'all' ? tasks : tasks.filter((t) => t.status === filter)).sort(byIdDesc)
+
+  return (
+    <main className="mx-auto min-h-screen max-w-4xl p-4 sm:p-8">
+      <header className="mb-6 flex flex-wrap items-center justify-between gap-3">
+        <h1 className="text-2xl font-bold text-gray-800">Dashboard</h1>
+        <div className="flex items-center gap-2">
+          <Link
+            to="/tasks/new"
+            className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          >
+            + Add task
+          </Link>
+          <Link
+            to="/play"
+            className="rounded-lg bg-[#D85A30] px-4 py-2 text-sm font-semibold text-white transition hover:bg-[#c24d27]"
+          >
+            ▶ Play
+          </Link>
+        </div>
+      </header>
+
+      <div className="mb-4 flex flex-wrap gap-2">
+        {FILTERS.map((f) => {
+          const active = filter === f.key
+          const count =
+            f.key === 'all' ? tasks.length : tasks.filter((t) => t.status === f.key).length
+          return (
+            <button
+              key={f.key}
+              onClick={() => setFilter(f.key)}
+              className={`rounded-full px-3 py-1 text-sm font-medium transition ${
+                active ? 'bg-gray-800 text-white' : 'border border-gray-300 text-gray-600 hover:bg-gray-50'
+              }`}
+            >
+              {f.label} <span className={active ? 'text-gray-300' : 'text-gray-400'}>{count}</span>
+            </button>
+          )
+        })}
+      </div>
+
+      {error && <p className="mb-3 text-sm text-red-600">{error}</p>}
+
+      {loading ? (
+        <p className="p-8 text-center text-gray-500">Loading…</p>
+      ) : visible.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-gray-200 p-10 text-center">
+          <p className="text-gray-500">
+            {tasks.length === 0 ? 'No tasks yet.' : `No ${FILTERS.find((f) => f.key === filter)?.label.toLowerCase()} tasks.`}
+          </p>
+          <Link to="/tasks/new" className="mt-2 inline-block text-sm text-[#a8431f] underline">
+            Add a task
+          </Link>
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-2xl border border-gray-200">
+          <table className="w-full min-w-[640px] text-left text-sm">
+            <thead className="border-b border-gray-200 bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
+              <tr>
+                <th className="px-4 py-3 font-medium">Title</th>
+                <th className="px-4 py-3 font-medium">Effort</th>
+                <th className="px-4 py-3 font-medium">Est.</th>
+                <th className="px-4 py-3 font-medium">Status</th>
+                <th className="px-4 py-3 text-right font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {visible.map((task) => {
+                const editing = editingId === task.id && editValues
+                if (editing) {
+                  return (
+                    <tr key={task.id} className="bg-[#D85A30]/5 align-top">
+                      <td className="px-4 py-2">
+                        <input
+                          autoFocus
+                          value={editValues.title}
+                          maxLength={MAX_TITLE}
+                          onChange={(e) => setEditValues({ ...editValues, title: e.target.value })}
+                          className="w-full rounded border border-gray-300 p-1.5"
+                        />
+                        {rowError && <p className="mt-1 text-xs text-red-600">{rowError}</p>}
+                      </td>
+                      <td className="px-4 py-2">
+                        <select
+                          value={editValues.complexity}
+                          onChange={(e) =>
+                            setEditValues({ ...editValues, complexity: e.target.value as TaskComplexity })
+                          }
+                          className="rounded border border-gray-300 p-1.5"
+                        >
+                          <option value="low">Low</option>
+                          <option value="medium">Medium</option>
+                          <option value="high">High</option>
+                        </select>
+                      </td>
+                      <td className="px-4 py-2">
+                        <input
+                          type="number"
+                          min={1}
+                          max={MAX_MINUTES}
+                          value={editValues.estimatedMinutes}
+                          onChange={(e) =>
+                            setEditValues({ ...editValues, estimatedMinutes: e.target.value })
+                          }
+                          className="w-20 rounded border border-gray-300 p-1.5"
+                        />
+                      </td>
+                      <td className="px-4 py-2">
+                        <select
+                          value={editValues.status}
+                          onChange={(e) =>
+                            setEditValues({ ...editValues, status: e.target.value as TaskStatus })
+                          }
+                          className="rounded border border-gray-300 p-1.5"
+                        >
+                          <option value="backlog">Backlog</option>
+                          <option value="in_progress">In progress</option>
+                          <option value="done">Done</option>
+                        </select>
+                      </td>
+                      <td className="px-4 py-2 text-right whitespace-nowrap">
+                        <button
+                          onClick={() => void saveEdit(task)}
+                          disabled={savingId === task.id}
+                          className="rounded bg-[#D85A30] px-3 py-1 text-xs font-semibold text-white hover:bg-[#c24d27] disabled:bg-gray-400"
+                        >
+                          {savingId === task.id ? 'Saving…' : 'Save'}
+                        </button>
+                        <button
+                          onClick={() => {
+                            setEditingId(null)
+                            setRowError(null)
+                          }}
+                          className="ml-2 text-xs text-gray-500 underline hover:text-gray-700"
+                        >
+                          Cancel
+                        </button>
+                      </td>
+                    </tr>
+                  )
+                }
+
+                const tag = COMPLEXITY_TAG[task.complexity]
+                const badge = STATUS_BADGE[task.status]
+                return (
+                  <tr key={task.id} className="hover:bg-gray-50">
+                    <td
+                      onClick={() => startEdit(task)}
+                      className="cursor-pointer px-4 py-3 font-medium text-gray-800"
+                      title="Click to edit"
+                    >
+                      {task.title}
+                    </td>
+                    <td onClick={() => startEdit(task)} className="cursor-pointer px-4 py-3">
+                      <span className={`rounded-full px-2 py-0.5 text-xs font-semibold ${tag.className}`}>
+                        {tag.label}
+                      </span>
+                    </td>
+                    <td onClick={() => startEdit(task)} className="cursor-pointer px-4 py-3 text-gray-500">
+                      {task.estimatedMinutes}m
+                    </td>
+                    <td onClick={() => startEdit(task)} className="cursor-pointer px-4 py-3">
+                      <span className={`rounded-full px-2 py-0.5 text-xs font-semibold ${badge.className}`}>
+                        {badge.label}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-right whitespace-nowrap">
+                      {task.status === 'backlog' && (
+                        <button
+                          onClick={() => void onStart(task)}
+                          className="text-xs font-semibold text-[#a8431f] hover:underline"
+                        >
+                          Start
+                        </button>
+                      )}
+                      {task.status === 'in_progress' && (
+                        <Link
+                          to={`/play/progress/${task.id}`}
+                          className="text-xs font-semibold text-[#a06d00] hover:underline"
+                        >
+                          Resume
+                        </Link>
+                      )}
+                      <Link
+                        to={`/tasks/${task.id}/edit`}
+                        className="ml-3 text-xs text-gray-500 hover:underline"
+                      >
+                        Edit
+                      </Link>
+                      <button
+                        onClick={() => onDelete(task)}
+                        className="ml-3 text-xs text-gray-500 hover:text-red-600 hover:underline"
+                      >
+                        Delete
+                      </button>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div className="mt-6 text-center">
+        <Link to="/" className="text-sm text-gray-500 underline hover:text-gray-700">
+          Back home
+        </Link>
+      </div>
+
+      {pendingTask && (
+        <div className="fixed bottom-6 left-1/2 flex -translate-x-1/2 items-center gap-4 rounded-lg bg-gray-900 px-4 py-3 text-sm text-white shadow-lg">
+          <span>
+            Deleted “{pendingTask.title.length > 32 ? pendingTask.title.slice(0, 32) + '…' : pendingTask.title}”
+          </span>
+          <button onClick={undoDelete} className="font-semibold text-[#F5A623] hover:underline">
+            Undo
+          </button>
+        </div>
+      )}
+    </main>
+  )
+}

--- a/client/src/pages/EditTask.tsx
+++ b/client/src/pages/EditTask.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { getTask, updateTask, type Task } from '@/lib/tasks'
+import { TaskForm, type TaskFormValues } from '@/components/TaskForm'
+
+/**
+ * Full-page task edit (issue #36). Opens from the dashboard's per-row Edit action.
+ * Today its fields match the dashboard's inline-editable columns; it exists as the
+ * home for fields beyond the table's columns (categories, tags, due dates,
+ * priorities) as those land — adding one won't force a table redesign.
+ */
+export function EditTask() {
+  const { id } = useParams()
+  const taskId = Number(id)
+  const navigate = useNavigate()
+  const [task, setTask] = useState<Task | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!Number.isInteger(taskId) || taskId <= 0) {
+      setError('Invalid task')
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    getTask(taskId)
+      .then((t) => !cancelled && setTask(t))
+      .catch((e) => !cancelled && setError(e instanceof Error ? e.message : 'Could not load the task'))
+      .finally(() => !cancelled && setLoading(false))
+    return () => {
+      cancelled = true
+    }
+  }, [taskId])
+
+  async function onSubmit(values: TaskFormValues) {
+    await updateTask(taskId, values)
+    navigate('/dashboard')
+  }
+
+  if (loading) {
+    return <main className="flex min-h-screen items-center justify-center text-gray-500">Loading…</main>
+  }
+
+  if (error || !task) {
+    return (
+      <main className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center">
+        <p className="text-gray-600">{error ?? 'Task not found'}</p>
+        <Link to="/dashboard" className="text-sm text-gray-500 underline hover:text-gray-700">
+          Back to dashboard
+        </Link>
+      </main>
+    )
+  }
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-gray-50 p-4">
+      <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-sm">
+        <h1 className="mb-5 text-center text-2xl font-bold text-gray-800">Edit task</h1>
+        <TaskForm
+          initial={{
+            title: task.title,
+            complexity: task.complexity,
+            estimatedMinutes: task.estimatedMinutes,
+          }}
+          submitLabel="Save changes"
+          submittingLabel="Saving…"
+          onSubmit={onSubmit}
+        />
+        <div className="mt-4 text-center text-sm">
+          <Link to="/dashboard" className="text-gray-500 underline hover:text-gray-700">
+            Cancel
+          </Link>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -25,9 +25,14 @@ export function Home() {
         >
           Let&apos;s go
         </Link>
-        <Link to="/tasks/new" className="text-sm text-gray-500 underline hover:text-gray-700">
-          Add a task
-        </Link>
+        <div className="flex gap-4 text-sm text-gray-500">
+          <Link to="/tasks/new" className="underline hover:text-gray-700">
+            Add a task
+          </Link>
+          <Link to="/dashboard" className="underline hover:text-gray-700">
+            Dashboard
+          </Link>
+        </div>
       </div>
 
       <footer className="absolute bottom-6 flex flex-col items-center gap-1 text-xs text-gray-400">

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -6,6 +6,8 @@ import { Choice } from '@/pages/Choice'
 import { TaskPresented } from '@/pages/TaskPresented'
 import { InProgress } from '@/pages/InProgress'
 import { AddTask } from '@/pages/AddTask'
+import { EditTask } from '@/pages/EditTask'
+import { Dashboard } from '@/pages/Dashboard'
 import { NotFound } from '@/pages/NotFound'
 import { ProtectedRoute } from '@/components/ProtectedRoute'
 
@@ -20,6 +22,8 @@ export const router = createBrowserRouter([
       { path: '/play/task', element: <TaskPresented /> },
       { path: '/play/progress/:id', element: <InProgress /> },
       { path: '/tasks/new', element: <AddTask /> },
+      { path: '/tasks/:id/edit', element: <EditTask /> },
+      { path: '/dashboard', element: <Dashboard /> },
     ],
   },
   { path: '*', element: <NotFound /> },


### PR DESCRIPTION
## Summary
Dashboard task list / management view — the Todoist/Linear-style admin surface (design confirmed with owner).

## Layout & editing (as agreed)
- `/dashboard`: all tasks in a dense table with **status filter tabs** (All / Backlog / In progress / Done, with counts).
- **Inline edit** of the four column fields — click a row to edit title, complexity, estimated minutes, and status in place; only changed fields are PATCHed (so an unchanged status doesn't re-trigger transition side effects).
- **Per-row Edit** button opens a full edit page (`/tasks/:id/edit`) — deliberate structural groundwork for fields beyond the table's columns (categories, tags, due dates, priorities). Today its field set matches the inline one, as expected.
- A shared **`TaskForm`** now backs both Add (#35) and Edit, so a future field is added in one place.

## Actions & manual selection
- Per row: **Start** (backlog → the in-progress screen, i.e. the manual selection entry the issue asks for), **Resume** (in-progress → #33), **Edit**, **Delete**.
- Header **Play** button into the guided flow + **Add task**. Dashboard entry added to Home.

## Delete UX (my call, per your delegation)
Undo toast rather than a confirm dialog: the row disappears immediately, the API DELETE is deferred ~5s, and Undo cancels the pending timer. Reasoning: it fits the fast, non-blocking inline-edit model (Linear/Todoist both do this) and needs no backend soft-delete. Trade-off accepted: navigating away during the window leaves the task (fail-safe).

## Scope / verification
- Reuses the #27 CRUD endpoints; `lib/tasks` gains `fetchTasks` / `updateTask` / `deleteTask` (+204 handling). No backend changes.
- Client typecheck, `vite build`, eslint pass. Verified end-to-end against MySQL: list, multi-field inline edit, inline status→done (awards points), and delete (204 → subsequent GET 404).
- Note: rebased onto the #29-inclusive develop so Home keeps the #29 redesign (adds the Dashboard link on top of it).

## Changes
- Dashboard: task list / management view (#36)

Closes #36