### PR TITLE
Close #37 - Dashboard: user points card

### DIFF
--- a/.changes/unreleased/37-dashboard-user-points-card.md
+++ b/.changes/unreleased/37-dashboard-user-points-card.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Changed -->
+- Dashboard: user points card ([#37](https://github.com/neturely/addiapp/issues/37))

--- a/client/src/components/PointsCard.tsx
+++ b/client/src/components/PointsCard.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react'
+import { fetchPoints, type PointsStats } from '@/lib/points'
+
+/**
+ * At-a-glance points summary for the dashboard (issue #37): lifetime total plus
+ * the current live daily multiplier and today's tally. Re-fetches whenever
+ * `refreshSignal` changes so it updates as tasks complete (PROJECT_SPEC §6/§7).
+ */
+export function PointsCard({ refreshSignal = 0 }: { refreshSignal?: number }) {
+  const [stats, setStats] = useState<PointsStats | null>(null)
+  const [failed, setFailed] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    fetchPoints()
+      .then((s) => !cancelled && setStats(s))
+      .catch(() => !cancelled && setFailed(true))
+    return () => {
+      cancelled = true
+    }
+  }, [refreshSignal])
+
+  if (failed) return null // a missing stats card shouldn't break the dashboard
+
+  const total = stats?.total ?? 0
+  const multiplier = stats?.today.currentMultiplier ?? 1
+  const tasksToday = stats?.today.tasksCompleted ?? 0
+  const pointsToday = stats?.today.pointsEarned ?? 0
+
+  return (
+    <section className="mb-6 flex flex-wrap items-center justify-between gap-4 rounded-2xl bg-gradient-to-r from-[#D85A30] to-[#e07a52] p-5 text-white">
+      <div>
+        <div className="text-xs font-medium uppercase tracking-wide text-white/80">Total points</div>
+        <div className="text-4xl font-extrabold tabular-nums">{total.toLocaleString()}</div>
+      </div>
+      <div className="flex gap-6 text-right">
+        <div>
+          <div className="text-xs font-medium uppercase tracking-wide text-white/80">Daily bonus</div>
+          <div className="text-2xl font-bold tabular-nums">×{+multiplier.toFixed(2)}</div>
+        </div>
+        <div>
+          <div className="text-xs font-medium uppercase tracking-wide text-white/80">Today</div>
+          <div className="text-2xl font-bold tabular-nums">{pointsToday}</div>
+          <div className="text-xs text-white/80">
+            {tasksToday} {tasksToday === 1 ? 'task' : 'tasks'}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -9,6 +9,7 @@ import {
   type TaskComplexity,
   type TaskStatus,
 } from '@/lib/tasks'
+import { PointsCard } from '@/components/PointsCard'
 
 type Filter = 'all' | TaskStatus
 
@@ -59,6 +60,7 @@ export function Dashboard() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [filter, setFilter] = useState<Filter>('all')
+  const [pointsRefresh, setPointsRefresh] = useState(0)
 
   const [editingId, setEditingId] = useState<number | null>(null)
   const [editValues, setEditValues] = useState<EditValues | null>(null)
@@ -159,6 +161,8 @@ export function Dashboard() {
       const updated = await updateTask(task.id, patch)
       setTasks((prev) => prev.map((t) => (t.id === task.id ? updated : t)).sort(byIdDesc))
       setEditingId(null)
+      // A status change may have awarded points — refresh the summary card.
+      if (patch.status) setPointsRefresh((n) => n + 1)
     } catch (e) {
       setRowError(e instanceof Error ? e.message : 'Could not save changes.')
     } finally {
@@ -196,6 +200,8 @@ export function Dashboard() {
           </Link>
         </div>
       </header>
+
+      <PointsCard refreshSignal={pointsRefresh} />
 
       <div className="mb-4 flex flex-wrap gap-2">
         {FILTERS.map((f) => {


### PR DESCRIPTION
## Summary
Dashboard user points card — at-a-glance points summary (PROJECT_SPEC §6/§7).

## What it does
- A `PointsCard` at the top of the dashboard showing **lifetime total points**, the **current live daily multiplier** (e.g. ×1.30), and **today's** points + tasks completed.
- Reads `GET /api/points` (#28). Re-fetches via a refresh signal that's bumped when a dashboard inline status change may have awarded points, so it updates as tasks complete. It also fetches fresh on mount, so returning from the play-flow completion shows the new total.
- Degrades gracefully (renders nothing) if the stats endpoint fails, rather than breaking the dashboard.

## Scope / verification
- Frontend only; no backend changes (`PointsCard.tsx` + wiring in `Dashboard.tsx`).
- Client typecheck, `vite build`, eslint pass. Confirmed the endpoint returns exactly what the card renders (total, `today.currentMultiplier`, `today.pointsEarned`, `today.tasksCompleted`).

## Changes
- Dashboard: user points card (#37)

Closes #37