### PR TITLE
Close #38 - User page (points / stats)

### DIFF
--- a/.changes/unreleased/38-user-page-points-stats.md
+++ b/.changes/unreleased/38-user-page-points-stats.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Changed -->
+- User page (points / stats) ([#38](https://github.com/neturely/addiapp/issues/38))

--- a/client/src/components/PointsCard.tsx
+++ b/client/src/components/PointsCard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { fetchPoints, type PointsStats } from '@/lib/points'
 
 /**
@@ -28,7 +29,10 @@ export function PointsCard({ refreshSignal = 0 }: { refreshSignal?: number }) {
   const pointsToday = stats?.today.pointsEarned ?? 0
 
   return (
-    <section className="mb-6 flex flex-wrap items-center justify-between gap-4 rounded-2xl bg-gradient-to-r from-[#D85A30] to-[#e07a52] p-5 text-white">
+    <Link
+      to="/stats"
+      className="mb-6 flex flex-wrap items-center justify-between gap-4 rounded-2xl bg-gradient-to-r from-[#D85A30] to-[#e07a52] p-5 text-white transition hover:brightness-105"
+    >
       <div>
         <div className="text-xs font-medium uppercase tracking-wide text-white/80">Total points</div>
         <div className="text-4xl font-extrabold tabular-nums">{total.toLocaleString()}</div>
@@ -46,6 +50,6 @@ export function PointsCard({ refreshSignal = 0 }: { refreshSignal?: number }) {
           </div>
         </div>
       </div>
-    </section>
+    </Link>
   )
 }

--- a/client/src/lib/points.ts
+++ b/client/src/lib/points.ts
@@ -18,3 +18,22 @@ export async function fetchPoints(): Promise<PointsStats> {
   if (!res.ok) throw new Error(`Request failed (${res.status})`)
   return res.json() as Promise<PointsStats>
 }
+
+/** Shape of GET /api/points/stats (issue #38 user page). */
+export type UserStats = {
+  total: number
+  lifetime: { tasksCompleted: number; speedBonusTotal: number }
+  today: {
+    date: string
+    tasksCompleted: number
+    pointsEarned: number
+    currentMultiplier: number
+  }
+  streak: { currentDays: number }
+}
+
+export async function fetchUserStats(): Promise<UserStats> {
+  const res = await fetch('/api/points/stats', { credentials: 'include' })
+  if (!res.ok) throw new Error(`Request failed (${res.status})`)
+  return res.json() as Promise<UserStats>
+}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -32,6 +32,9 @@ export function Home() {
           <Link to="/dashboard" className="underline hover:text-gray-700">
             Dashboard
           </Link>
+          <Link to="/stats" className="underline hover:text-gray-700">
+            Stats
+          </Link>
         </div>
       </div>
 

--- a/client/src/pages/Stats.tsx
+++ b/client/src/pages/Stats.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { Mascot } from '@/components/Mascot'
+import { fetchUserStats, type UserStats } from '@/lib/points'
+
+function Tile({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div className="rounded-2xl border border-gray-200 bg-white p-5 text-center">
+      <div className="text-xs font-medium uppercase tracking-wide text-gray-400">{label}</div>
+      <div className="mt-1 text-3xl font-extrabold tabular-nums text-gray-800">{value}</div>
+      {hint && <div className="mt-0.5 text-xs text-gray-400">{hint}</div>}
+    </div>
+  )
+}
+
+/**
+ * User points/stats page (issue #38, PROJECT_SPEC §7). A dedicated at-a-glance
+ * view of lifetime totals, tasks completed, day streak, speed bonuses earned, and
+ * the current live daily multiplier — reading GET /api/points/stats.
+ */
+export function Stats() {
+  const [stats, setStats] = useState<UserStats | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    fetchUserStats()
+      .then((s) => !cancelled && setStats(s))
+      .catch((e) => !cancelled && setError(e instanceof Error ? e.message : 'Could not load stats'))
+      .finally(() => !cancelled && setLoading(false))
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  if (loading) {
+    return <main className="flex min-h-screen items-center justify-center text-gray-500">Loading…</main>
+  }
+  if (error || !stats) {
+    return (
+      <main className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center">
+        <p className="text-gray-600">{error ?? 'No stats yet'}</p>
+        <Link to="/" className="text-sm text-gray-500 underline hover:text-gray-700">
+          Back home
+        </Link>
+      </main>
+    )
+  }
+
+  const { total, lifetime, today, streak } = stats
+
+  return (
+    <main className="mx-auto min-h-screen max-w-2xl p-4 sm:p-8">
+      <div className="mb-6 flex flex-col items-center gap-3 text-center">
+        <Mascot mood="happy" />
+        <h1 className="text-2xl font-bold text-gray-800">Your stats</h1>
+      </div>
+
+      <section className="mb-4 rounded-2xl bg-gradient-to-r from-[#D85A30] to-[#e07a52] p-6 text-center text-white">
+        <div className="text-xs font-medium uppercase tracking-wide text-white/80">Total points</div>
+        <div className="text-5xl font-extrabold tabular-nums">{total.toLocaleString()}</div>
+      </section>
+
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <Tile label="Tasks done" value={lifetime.tasksCompleted.toLocaleString()} />
+        <Tile
+          label="Day streak"
+          value={`${streak.currentDays}`}
+          hint={streak.currentDays === 1 ? 'day 🔥' : 'days 🔥'}
+        />
+        <Tile label="Speed bonus" value={`+${lifetime.speedBonusTotal.toLocaleString()}`} hint="earned ⚡" />
+        <Tile label="Daily bonus" value={`×${+today.currentMultiplier.toFixed(2)}`} hint="next task" />
+      </div>
+
+      <p className="mt-4 text-center text-sm text-gray-500">
+        Today: <span className="font-semibold text-gray-700">{today.pointsEarned}</span> pts from{' '}
+        {today.tasksCompleted} {today.tasksCompleted === 1 ? 'task' : 'tasks'}
+      </p>
+
+      <div className="mt-6 flex justify-center gap-4 text-sm">
+        <Link to="/play" className="text-[#a8431f] underline hover:text-[#7f3217]">
+          Play
+        </Link>
+        <Link to="/dashboard" className="text-gray-500 underline hover:text-gray-700">
+          Dashboard
+        </Link>
+        <Link to="/" className="text-gray-500 underline hover:text-gray-700">
+          Home
+        </Link>
+      </div>
+    </main>
+  )
+}

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -8,6 +8,7 @@ import { InProgress } from '@/pages/InProgress'
 import { AddTask } from '@/pages/AddTask'
 import { EditTask } from '@/pages/EditTask'
 import { Dashboard } from '@/pages/Dashboard'
+import { Stats } from '@/pages/Stats'
 import { NotFound } from '@/pages/NotFound'
 import { ProtectedRoute } from '@/components/ProtectedRoute'
 
@@ -24,6 +25,7 @@ export const router = createBrowserRouter([
       { path: '/tasks/new', element: <AddTask /> },
       { path: '/tasks/:id/edit', element: <EditTask /> },
       { path: '/dashboard', element: <Dashboard /> },
+      { path: '/stats', element: <Stats /> },
     ],
   },
   { path: '*', element: <NotFound /> },

--- a/server/src/points/award.ts
+++ b/server/src/points/award.ts
@@ -116,3 +116,71 @@ export async function getPointsStats(userId: number): Promise<PointsStats> {
     basePoints: BASE_POINTS,
   }
 }
+
+/** Previous calendar date (YYYY-MM-DD) — dates are plain, so UTC-midnight math is safe. */
+function prevDate(dateStr: string): string {
+  const d = new Date(`${dateStr}T00:00:00Z`)
+  d.setUTCDate(d.getUTCDate() - 1)
+  return d.toISOString().slice(0, 10)
+}
+
+export type UserStats = {
+  total: number
+  lifetime: { tasksCompleted: number; speedBonusTotal: number }
+  today: { date: string; tasksCompleted: number; pointsEarned: number; currentMultiplier: number }
+  /** Consecutive days (in APP_TIMEZONE) with ≥1 completion, counting back from today. */
+  streak: { currentDays: number }
+}
+
+/**
+ * Richer points/stats for the dedicated user stats page (issue #38). Kept separate
+ * from getPointsStats so the frequently-refreshed dashboard card stays lean.
+ */
+export async function getUserStats(userId: number): Promise<UserStats> {
+  const agg = await db
+    .select({
+      total: sql<string>`COALESCE(SUM(${pointsLog.totalPoints}), 0)`,
+      tasks: sql<string>`COUNT(*)`,
+      speed: sql<string>`COALESCE(SUM(${pointsLog.speedBonus}), 0)`,
+    })
+    .from(pointsLog)
+    .where(eq(pointsLog.userId, userId))
+  const total = Number(agg[0]?.total ?? 0)
+  const lifetimeTasks = Number(agg[0]?.tasks ?? 0)
+  const speedBonusTotal = Number(agg[0]?.speed ?? 0)
+
+  const today = todayInTz()
+  const todayRow = await db
+    .select()
+    .from(dailyStats)
+    .where(and(eq(dailyStats.userId, userId), eq(dailyStats.statDate, today)))
+    .limit(1)
+  const tasksCompleted = todayRow[0]?.tasksCompleted ?? 0
+  const pointsEarned = todayRow[0]?.pointsEarned ?? 0
+
+  // Streak: walk back day-by-day over the set of active dates. If today has no
+  // completion yet, start from yesterday so a fresh day doesn't zero the streak.
+  const dayRows = await db
+    .select({ statDate: dailyStats.statDate, tasksCompleted: dailyStats.tasksCompleted })
+    .from(dailyStats)
+    .where(eq(dailyStats.userId, userId))
+  const activeDays = new Set(dayRows.filter((r) => r.tasksCompleted > 0).map((r) => r.statDate))
+  let cursor = activeDays.has(today) ? today : prevDate(today)
+  let currentDays = 0
+  while (activeDays.has(cursor)) {
+    currentDays += 1
+    cursor = prevDate(cursor)
+  }
+
+  return {
+    total,
+    lifetime: { tasksCompleted: lifetimeTasks, speedBonusTotal },
+    today: {
+      date: today,
+      tasksCompleted,
+      pointsEarned,
+      currentMultiplier: dailyMultiplier(tasksCompleted + 1),
+    },
+    streak: { currentDays },
+  }
+}

--- a/server/src/routes/points.ts
+++ b/server/src/routes/points.ts
@@ -1,17 +1,26 @@
 import { Router } from 'express'
 import { requireAuth } from '../middleware/requireAuth.js'
 import { asyncHandler } from '../lib/asyncHandler.js'
-import { getPointsStats } from '../points/award.js'
+import { getPointsStats, getUserStats } from '../points/award.js'
 
 export const pointsRouter = Router()
 
 pointsRouter.use(requireAuth)
 
-// GET /api/points — points/stats summary for the authed user.
+// GET /api/points — lean points summary for the authed user (dashboard card #37).
 pointsRouter.get(
   '/',
   asyncHandler(async (req, res) => {
     const stats = await getPointsStats(req.user!.id)
+    res.json(stats)
+  }),
+)
+
+// GET /api/points/stats — richer lifetime stats for the user page (#38).
+pointsRouter.get(
+  '/stats',
+  asyncHandler(async (req, res) => {
+    const stats = await getUserStats(req.user!.id)
     res.json(stats)
   }),
 )


### PR DESCRIPTION
## Summary
User points/stats page (PROJECT_SPEC §7) — a dedicated at-a-glance stats screen.

## Backend
- New `GET /api/points/stats` (`getUserStats`) with the lifetime aggregates the lean `/api/points` (dashboard card #37) deliberately doesn't carry:
  - lifetime **tasks completed**, total **speed bonus earned**,
  - a **day streak** — consecutive days (in the app timezone) with ≥1 completion, counting back from today (a fresh, not-yet-active today doesn't zero it; a gap breaks it).
  Kept as a separate endpoint so the frequently-refreshed card stays cheap.

## Frontend
- New `/stats` page: total-points hero + stat tiles (tasks done, day streak 🔥, speed bonus ⚡, current daily multiplier) + today's summary.
- Entry points: **Stats** link on Home; the dashboard **points card now links to `/stats`**.

## Design note
The screen was flagged "not designed" — layout is a standard stat-tile grid; the stat set follows the issue's enumerated scope (totals, tasks completed, daily multiplier/streak, speed bonuses). I read "streak" as a distinct day-streak and built it; trivial to drop if you'd rather lean on the multiplier alone.

## Verification
Server + client typecheck, `vite build`, eslint pass. Endpoint verified against MySQL truth (total 153, 9 tasks, +44 speed bonus). Streak logic exercised with injected rows: today→1, +yesterday→2, and a gap day correctly stops at 2 (test rows cleaned up).

## Changes
- User page: points / stats (#38)

Closes #38