### PR TITLE
Close #39 - Deploy pipeline rewrite (GitHub Actions + build + FTP + Express)

### DIFF
--- a/.changes/unreleased/39-deploy-pipeline-rewrite-github-actions-build.md
+++ b/.changes/unreleased/39-deploy-pipeline-rewrite-github-actions-build.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Changed -->
+- Deploy pipeline rewrite (GitHub Actions + build + FTP + Express) ([#39](https://github.com/neturely/addiapp/issues/39))

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+name: Deploy to production (KnownHost)
+
+# Builds the SPA and ships the static build + PHP API to the KnownHost account
+# over SSH, then runs migrations. PHP has no long-running process, so there is
+# nothing to restart. One-time server setup is documented in docs/DEPLOY.md.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Build the SPA
+        run: |
+          npm ci
+          npm run build -w client
+
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -p "${{ secrets.DEPLOY_SSH_PORT }}" "${{ secrets.DEPLOY_SSH_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Deploy SPA → public_html
+        run: |
+          rsync -az --delete \
+            --exclude='.well-known' --exclude='api' --exclude='cgi-bin' --exclude='.ftpquota' \
+            -e "ssh -i ~/.ssh/deploy_key -p ${{ secrets.DEPLOY_SSH_PORT }}" \
+            client/dist/ "${{ secrets.DEPLOY_SSH_USER }}@${{ secrets.DEPLOY_SSH_HOST }}:public_html/"
+
+      - name: Deploy PHP API → ~/api
+        run: |
+          rsync -az --delete \
+            --exclude='config.php' --exclude='config.example.php' \
+            -e "ssh -i ~/.ssh/deploy_key -p ${{ secrets.DEPLOY_SSH_PORT }}" \
+            api/ "${{ secrets.DEPLOY_SSH_USER }}@${{ secrets.DEPLOY_SSH_HOST }}:api/"
+
+      - name: Run migrations
+        run: |
+          ssh -i ~/.ssh/deploy_key -p "${{ secrets.DEPLOY_SSH_PORT }}" \
+            "${{ secrets.DEPLOY_SSH_USER }}@${{ secrets.DEPLOY_SSH_HOST }}" 'php ~/api/migrate.php'

--- a/client/public/.htaccess
+++ b/client/public/.htaccess
@@ -1,0 +1,26 @@
+# AddiApp SPA — served from public_html. Shipped with the Vite build.
+<IfModule mod_rewrite.c>
+  RewriteEngine On
+  RewriteBase /
+
+  # /api is a symlink to the PHP app (api/public) — let it handle its own routes.
+  RewriteRule ^api(/|$) - [L]
+
+  # Serve real files and directories as-is.
+  RewriteCond %{REQUEST_FILENAME} -f [OR]
+  RewriteCond %{REQUEST_FILENAME} -d
+  RewriteRule ^ - [L]
+
+  # Everything else is client-side routing → the SPA entrypoint.
+  RewriteRule ^ index.html [L]
+</IfModule>
+
+# Long-cache fingerprinted assets; never cache the HTML shell.
+<IfModule mod_headers.c>
+  <FilesMatch "\.(?:js|css|woff2?|png|jpg|svg|ico)$">
+    Header set Cache-Control "public, max-age=31536000, immutable"
+  </FilesMatch>
+  <FilesMatch "\.html$">
+    Header set Cache-Control "no-cache"
+  </FilesMatch>
+</IfModule>

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,52 @@
+# Deployment
+
+Production is the KnownHost cPanel/LiteSpeed account (`addiapp@209.42.255.1`,
+same Basic Plus Reseller box as wptips.com). The backend is PHP, so a deploy is
+just files + migrations — **no process to restart**.
+
+## Pipeline (`.github/workflows/deploy.yml`)
+
+Runs on push to `main` (or manual dispatch):
+
+1. `npm ci` + `npm run build -w client` → `client/dist`.
+2. `rsync --delete` `client/dist/` → `~/public_html` (keeps `.well-known`,
+   `cgi-bin`, and the `api` symlink; old files are pruned).
+3. `rsync --delete` `api/` → `~/api` (keeps `config.php`).
+4. `ssh … php ~/api/migrate.php`.
+
+### Required GitHub Actions secrets
+
+| Secret | Value |
+| --- | --- |
+| `DEPLOY_SSH_HOST` | `209.42.255.1` |
+| `DEPLOY_SSH_USER` | `addiapp` |
+| `DEPLOY_SSH_PORT` | `22` |
+| `DEPLOY_SSH_KEY`  | private half of a dedicated deploy keypair (public half in the account's `~/.ssh/authorized_keys`) |
+
+## One-time server setup
+
+1. **MySQL** (cPanel → MySQL Databases, or `uapi Mysql …` over SSH): create DB
+   `addiapp_prod` + user `addiapp_app` with ALL privileges.
+2. **`~/api/config.php`** (outside the web root, never committed):
+   ```php
+   <?php return [
+     'databaseUrl'  => 'mysql://addiapp_app:PASSWORD@localhost/addiapp_prod',
+     'appUrl'       => 'https://addiapp.com',
+     'appTimezone'  => 'Europe/Stockholm',
+     'resendApiKey' => 'RESEND_KEY',   // real key + verified domain (#65) for live email
+     'emailFrom'    => 'AddiApp <no-reply@addiapp.com>',
+     'isProd'       => true,
+   ];
+   ```
+   (`localhost` with no port → PHP uses the cPanel MySQL socket.)
+3. **Routing**: symlink `~/public_html/api` → `~/api/public` so `addiapp.com/api/*`
+   hits the PHP front controller. The SPA `.htaccess` (shipped from
+   `client/public/.htaccess`) handles client-side routing and skips `/api`.
+4. First deploy runs migrations, creating the schema in `addiapp_prod`.
+
+## Email in production
+
+`resendApiKey` must be a real Resend key **and** `addiapp.com` must be verified
+in Resend (#65) before live sends work — until then registration succeeds but
+verification emails aren't delivered (logged as best-effort failures). Set
+`emailFrom` to a verified-domain sender once #65 is done.


### PR DESCRIPTION
## Summary
Production deploy pipeline — GitHub Actions → KnownHost over SSH. The issue text predates the PHP rewrite; reality is now simpler (SSH confirmed, PHP backend = no process to restart), so a deploy is just files + migrations.

## Pipeline (`.github/workflows/deploy.yml`)
On push to `main` (or manual dispatch): build the SPA, `rsync --delete` `client/dist` → `public_html` and `api/` → `~/api` (preserving `config.php`, `.well-known`, `cgi-bin`, the `api` symlink), then `php ~/api/migrate.php` over SSH.

- `client/public/.htaccess` — SPA client-side routing (ships with the build); skips `/api`, which is a symlink to the PHP front controller.
- `docs/DEPLOY.md` — pipeline, required secrets, and one-time server setup.

## Done on the server (validated end-to-end against production)
- Created prod MySQL `addiapp_prod` + user via `uapi`; wrote `~/api/config.php` (secrets, outside the web root, `isProd`); symlinked `public_html/api` → `~/api/public`; backed up + cleaned the old static site.
- Generated a dedicated deploy SSH key (public half in the account's `authorized_keys`); set GitHub secrets `DEPLOY_SSH_HOST/USER/PORT/KEY`.
- **First deploy performed**: migrations created the schema in `addiapp_prod`, `https://addiapp.com/` serves the SPA, `https://addiapp.com/api/health` returns 200, and deep routes (`/dashboard`) client-route correctly.

So merging into `main` will auto-deploy from here on.

## Follow-up (not blocking)
Email in production is currently unset: `~/api/config.php` has an empty `resendApiKey`, so verification/reset emails aren't sent (registration still succeeds; best-effort failures are logged). Add a real Resend key + verify the `addiapp.com` domain (#65), and set `emailFrom` to a verified sender.

## Changes
- Deploy pipeline: GitHub Actions → KnownHost over SSH (#39)

Closes #39