### PR TITLE
Close #62 - Password reset flow (request + confirm, Brevo email, rate-limited)

### DIFF
--- a/.changes/unreleased/62-password-reset-flow-request-confirm-brevo.md
+++ b/.changes/unreleased/62-password-reset-flow-request-confirm-brevo.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Changed -->
+- Password reset flow (request + confirm, Brevo email, rate-limited) ([#62](https://github.com/neturely/addiapp/issues/62))

--- a/client/src/pages/ForgotPassword.tsx
+++ b/client/src/pages/ForgotPassword.tsx
@@ -1,0 +1,83 @@
+import { useState, type FormEvent } from 'react'
+import { Link } from 'react-router-dom'
+import { apiRequest } from '@/lib/api'
+
+/**
+ * Request a password reset (issue #62). Always shows the same confirmation
+ * regardless of whether the account exists — no account enumeration (the server
+ * is likewise non-enumerating and rate-limited).
+ */
+export function ForgotPassword() {
+  const [email, setEmail] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [sent, setSent] = useState(false)
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault()
+    setSubmitting(true)
+    try {
+      await apiRequest('/auth/forgot-password', {
+        method: 'POST',
+        body: JSON.stringify({ email }),
+      })
+    } catch {
+      // Swallow — never reveal whether the account exists.
+    } finally {
+      setSent(true)
+      setSubmitting(false)
+    }
+  }
+
+  if (sent) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-100 p-4">
+        <div className="w-full max-w-sm rounded-lg bg-white p-6 text-center shadow">
+          <h1 className="mb-2 text-xl font-bold">Check your email 📬</h1>
+          <p className="text-sm text-gray-600">
+            If an account exists for <strong>{email}</strong>, a password reset link is on its way.
+            The link expires in 1 hour.
+          </p>
+          <p className="mt-4 text-sm">
+            <Link to="/login" className="text-blue-600 underline">
+              Back to sign in
+            </Link>
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-100 p-4">
+      <div className="w-full max-w-sm rounded-lg bg-white p-6 shadow">
+        <h1 className="mb-1 text-center text-xl font-bold">Forgot your password?</h1>
+        <p className="mb-4 text-center text-sm text-gray-500">
+          Enter your email and we&apos;ll send a reset link.
+        </p>
+        <form onSubmit={onSubmit} className="space-y-4">
+          <input
+            className="w-full rounded border p-2"
+            type="email"
+            required
+            autoComplete="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <button
+            type="submit"
+            disabled={submitting}
+            className="w-full rounded bg-blue-600 py-2 text-white disabled:bg-gray-400"
+          >
+            {submitting ? 'Sending…' : 'Send reset link'}
+          </button>
+        </form>
+        <p className="mt-4 text-center text-sm">
+          <Link to="/login" className="text-blue-600 underline">
+            Back to sign in
+          </Link>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -92,6 +92,11 @@ export function Login() {
             Register
           </Link>
         </p>
+        <p className="mt-1 text-center text-sm">
+          <Link to="/forgot-password" className="text-blue-600 underline">
+            Forgot your password?
+          </Link>
+        </p>
       </div>
     </div>
   )

--- a/client/src/pages/ResetPassword.tsx
+++ b/client/src/pages/ResetPassword.tsx
@@ -1,0 +1,111 @@
+import { useState, type FormEvent } from 'react'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import { apiRequest } from '@/lib/api'
+
+/**
+ * Set a new password from a reset link (issue #62). Reads the token from the URL,
+ * posts it with the new password, and on success sends the user to sign in
+ * (the server has invalidated all their old sessions).
+ */
+export function ResetPassword() {
+  const [params] = useSearchParams()
+  const token = params.get('token')
+  const navigate = useNavigate()
+  const [password, setPassword] = useState('')
+  const [confirm, setConfirm] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [done, setDone] = useState(false)
+
+  if (!token) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-100 p-4">
+        <div className="w-full max-w-sm rounded-lg bg-white p-6 text-center shadow">
+          <h1 className="mb-2 text-xl font-bold">Invalid reset link</h1>
+          <p className="text-sm text-gray-600">This link is missing its reset token.</p>
+          <p className="mt-4 text-sm">
+            <Link to="/forgot-password" className="text-blue-600 underline">
+              Request a new link
+            </Link>
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault()
+    setError(null)
+    if (password.length < 8) {
+      setError('Password must be at least 8 characters.')
+      return
+    }
+    if (password !== confirm) {
+      setError('Passwords do not match.')
+      return
+    }
+    setSubmitting(true)
+    try {
+      await apiRequest('/auth/reset-password', {
+        method: 'POST',
+        body: JSON.stringify({ token, password }),
+      })
+      setDone(true)
+      setTimeout(() => navigate('/login', { replace: true }), 1500)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not reset your password.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (done) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-100 p-4">
+        <div className="w-full max-w-sm rounded-lg bg-white p-6 text-center shadow">
+          <h1 className="mb-2 text-xl font-bold">Password reset ✅</h1>
+          <p className="text-sm text-gray-600">Sending you to sign in with your new password…</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-100 p-4">
+      <div className="w-full max-w-sm rounded-lg bg-white p-6 shadow">
+        <h1 className="mb-4 text-center text-xl font-bold">Choose a new password</h1>
+        <form onSubmit={onSubmit} className="space-y-4">
+          <input
+            className="w-full rounded border p-2"
+            type="password"
+            autoComplete="new-password"
+            placeholder="New password (min 8 characters)"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <input
+            className="w-full rounded border p-2"
+            type="password"
+            autoComplete="new-password"
+            placeholder="Confirm new password"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+          />
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          <button
+            type="submit"
+            disabled={submitting}
+            className="w-full rounded bg-blue-600 py-2 text-white disabled:bg-gray-400"
+          >
+            {submitting ? 'Resetting…' : 'Reset password'}
+          </button>
+        </form>
+        <p className="mt-4 text-center text-sm">
+          <Link to="/login" className="text-blue-600 underline">
+            Back to sign in
+          </Link>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -3,6 +3,8 @@ import { Home } from '@/pages/Home'
 import { Login } from '@/pages/Login'
 import { Register } from '@/pages/Register'
 import { Verify } from '@/pages/Verify'
+import { ForgotPassword } from '@/pages/ForgotPassword'
+import { ResetPassword } from '@/pages/ResetPassword'
 import { Choice } from '@/pages/Choice'
 import { TaskPresented } from '@/pages/TaskPresented'
 import { InProgress } from '@/pages/InProgress'
@@ -17,6 +19,8 @@ export const router = createBrowserRouter([
   { path: '/login', element: <Login /> },
   { path: '/register', element: <Register /> },
   { path: '/verify', element: <Verify /> },
+  { path: '/forgot-password', element: <ForgotPassword /> },
+  { path: '/reset', element: <ResetPassword /> },
   {
     element: <ProtectedRoute />,
     children: [

--- a/server/src/auth/sessions.ts
+++ b/server/src/auth/sessions.ts
@@ -43,6 +43,11 @@ export async function deleteSession(sessionId: string): Promise<void> {
   await db.delete(sessions).where(eq(sessions.id, sessionId))
 }
 
+/** Revoke ALL of a user's sessions — used after a password reset (issue #62). */
+export async function deleteUserSessions(userId: number): Promise<void> {
+  await db.delete(sessions).where(eq(sessions.userId, userId))
+}
+
 export async function purgeExpiredSessions(): Promise<void> {
   await db.delete(sessions).where(lt(sessions.expiresAt, new Date()))
 }

--- a/server/src/email/templates.ts
+++ b/server/src/email/templates.ts
@@ -23,3 +23,19 @@ export function verificationEmail(to: string, token: string): EmailMessage {
     text: `Welcome to AddiApp! Verify your email: ${link} (expires in 24 hours). If you didn't sign up, ignore this email.`,
   }
 }
+
+export function passwordResetEmail(to: string, token: string): EmailMessage {
+  const link = `${config.appUrl}/reset?token=${token}`
+  return {
+    to,
+    subject: 'Reset your AddiApp password',
+    html: wrap(
+      'Reset your password',
+      `<p>We got a request to reset your AddiApp password. Choose a new one here:</p>
+       <p><a href="${link}">Reset my password</a></p>
+       <p style="color:#666;font-size:13px">Or paste this link into your browser:<br>${link}</p>
+       <p style="color:#666;font-size:13px">This link expires in 1 hour. If you didn't request this, you can safely ignore this email — your password won't change.</p>`,
+    ),
+    text: `Reset your AddiApp password: ${link} (expires in 1 hour). If you didn't request this, ignore this email — your password won't change.`,
+  }
+}

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -8,12 +8,13 @@ import { hashPassword, verifyPassword } from '../auth/passwords.js'
 import {
   createSession,
   deleteSession,
+  deleteUserSessions,
   SESSION_COOKIE,
   SESSION_MAX_AGE_MS,
 } from '../auth/sessions.js'
 import { createEmailToken, consumeEmailToken } from '../auth/emailTokens.js'
 import { emailService } from '../email/index.js'
-import { verificationEmail } from '../email/templates.js'
+import { verificationEmail, passwordResetEmail } from '../email/templates.js'
 import { requireAuth } from '../middleware/requireAuth.js'
 import { asyncHandler } from '../lib/asyncHandler.js'
 import { config } from '../config.js'
@@ -33,9 +34,21 @@ const loginSchema = z.object({
 
 const verifySchema = z.object({ token: z.string().min(1) })
 const emailOnlySchema = z.object({ email: z.string().email() })
+const resetSchema = z.object({
+  token: z.string().min(1),
+  password: z.string().min(8, 'Password must be at least 8 characters'),
+})
 
 // Light rate limit on the resend endpoint to curb abuse/spam.
 const resendLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+})
+
+// Same treatment for the password-reset request (email-sending, enumeration-prone).
+const forgotPasswordLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   limit: 5,
   standardHeaders: true,
@@ -55,6 +68,11 @@ function setSessionCookie(res: Response, sid: string): void {
 async function sendVerificationEmail(userId: number, email: string): Promise<void> {
   const token = await createEmailToken(userId, 'verify')
   await emailService.send(verificationEmail(email, token))
+}
+
+async function sendPasswordResetEmail(userId: number, email: string): Promise<void> {
+  const token = await createEmailToken(userId, 'reset')
+  await emailService.send(passwordResetEmail(email, token))
 }
 
 // POST /register — creates the account (unverified) and emails a verification
@@ -170,6 +188,51 @@ authRouter.post(
     res.json({
       message: 'If that account exists and is unverified, a new verification link has been sent.',
     })
+  }),
+)
+
+// POST /forgot-password — request a reset. Always 200 (no account enumeration),
+// rate-limited. Emails a reset link only if the account actually exists.
+authRouter.post(
+  '/forgot-password',
+  forgotPasswordLimiter,
+  asyncHandler(async (req, res) => {
+    const parsed = emailOnlySchema.safeParse(req.body)
+    if (!parsed.success) {
+      res.status(400).json({ error: 'Invalid email' })
+      return
+    }
+    const rows = await db.select().from(users).where(eq(users.email, parsed.data.email)).limit(1)
+    const user = rows[0]
+    if (user) {
+      await sendPasswordResetEmail(user.id, user.email)
+    }
+    res.json({
+      message: 'If an account exists for that email, a password reset link has been sent.',
+    })
+  }),
+)
+
+// POST /reset-password — consume a reset token, set the new password (bcrypt),
+// and revoke ALL of the user's existing sessions. Does not log in: the user
+// signs in fresh with the new password.
+authRouter.post(
+  '/reset-password',
+  asyncHandler(async (req, res) => {
+    const parsed = resetSchema.safeParse(req.body)
+    if (!parsed.success) {
+      res.status(400).json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' })
+      return
+    }
+    const userId = await consumeEmailToken(parsed.data.token, 'reset')
+    if (userId === null) {
+      res.status(400).json({ error: 'This reset link is invalid or has expired.' })
+      return
+    }
+    const passwordHash = await hashPassword(parsed.data.password)
+    await db.update(users).set({ passwordHash }).where(eq(users.id, userId))
+    await deleteUserSessions(userId)
+    res.json({ message: 'Your password has been reset. You can now sign in.' })
   }),
 )
 


### PR DESCRIPTION
## Summary
Password reset flow — request + confirm, using Resend, reusing #61's email service the way it was designed to be reused.

## Reuse (no new infra)
`email_tokens` already supports the `reset` type (1h TTL) and `emailService` is the same swappable transport (Resend / console). #62 just adds a template + two routes + `deleteUserSessions`.

## Backend
- `POST /forgot-password` — rate-limited, always 200 (no account enumeration); sends a reset link only if the account exists.
- `POST /reset-password` — validates the token, sets the new password via bcrypt, and **revokes ALL of the user's sessions**. Does not log in — the user signs in fresh with the new password.
- `passwordResetEmail` template (`/reset?token=` link); `deleteUserSessions` in sessions.ts.

## Frontend
- `/forgot-password` (email → generic confirmation) and `/reset` (new password + confirm, reads token from URL → on success routes to sign in). "Forgot your password?" link added to Login.

## Verification (console transport, end-to-end against MySQL)
request → 200 generic; reset with valid token → 200; **old session then 401** (invalidated); old password → 401; new password → 200; token is single-use (reuse → 400); too-short password → 400; unknown email → 200 with **no token created** (non-enumerating). Server + client typecheck, `vite build`, eslint all pass.

Note: like verification, live Resend sends to unverified recipients fail until domain verification (#65); the console transport covers dev, and the register-send-failure hardening is #67.

## Changes
- Password reset flow: request + confirm, Resend email (#62)

Closes #62