### PR TITLE
Close #67 - Harden registration against email-send failures

### DIFF
--- a/.changes/unreleased/67-harden-registration-against-email-send-failures.md
+++ b/.changes/unreleased/67-harden-registration-against-email-send-failures.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Changed -->
+- Harden registration against email-send failures ([#67](https://github.com/neturely/addiapp/issues/67))

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -75,6 +75,21 @@ async function sendPasswordResetEmail(userId: number, email: string): Promise<vo
   await emailService.send(passwordResetEmail(email, token))
 }
 
+/**
+ * Send a transactional email without letting a provider hiccup fail the request
+ * (issue #67). The DB state (account created / token stored) is already
+ * committed and the user can always trigger a resend, so a send failure is
+ * logged loudly server-side but does not become an error response. Never
+ * silently swallowed — it's always logged.
+ */
+async function sendEmailBestEffort(context: string, send: () => Promise<void>): Promise<void> {
+  try {
+    await send()
+  } catch (err) {
+    console.error(`[addiapp-server] email send failed (${context}):`, err)
+  }
+}
+
 // POST /register — creates the account (unverified) and emails a verification
 // link. Does NOT log the user in: login is blocked until the email is verified.
 authRouter.post(
@@ -101,7 +116,12 @@ authRouter.post(
     const [result] = await db
       .insert(users)
       .values({ email, passwordHash, displayName: displayName ?? null })
-    await sendVerificationEmail(result.insertId, email)
+    // The account exists now — a failed verification email must NOT fail the
+    // registration (issue #67). If the send throws, it's logged and the user can
+    // request a fresh link via /resend-verification.
+    await sendEmailBestEffort(`verification for user ${result.insertId} <${email}>`, () =>
+      sendVerificationEmail(result.insertId, email),
+    )
 
     res.status(201).json({
       message: 'Account created. Check your email to verify your address before signing in.',
@@ -183,7 +203,11 @@ authRouter.post(
     const rows = await db.select().from(users).where(eq(users.email, parsed.data.email)).limit(1)
     const user = rows[0]
     if (user && !user.emailVerified) {
-      await sendVerificationEmail(user.id, user.email)
+      // Best-effort so a provider hiccup on the retry path stays non-enumerating
+      // (same generic 200) rather than 500ing (issue #67).
+      await sendEmailBestEffort(`resend-verification for user ${user.id} <${user.email}>`, () =>
+        sendVerificationEmail(user.id, user.email),
+      )
     }
     res.json({
       message: 'If that account exists and is unverified, a new verification link has been sent.',


### PR DESCRIPTION
## Summary
Registration no longer fails when the verification email can't be sent.

## Problem
Register created the user, then `await`ed the verification email inline — so a provider hiccup (e.g. Resend rejecting a recipient in test mode) threw and turned a successful signup into a 500. The account existed, but the user had no idea whether they'd registered.

## Fix
Decouple account creation from the email send. The DB write is authoritative; the verification send is now **best-effort** via a small `sendEmailBestEffort(context, send)` helper — on failure it's **logged loudly server-side** (never silently swallowed) but register still returns **201**. Recovery is `/resend-verification`, hardened the same way so a repeat send failure stays a generic **200** (preserving non-enumeration) instead of 500. Normal path unchanged. One file (`server/src/routes/auth.ts`).

## Verification
- Forced failure (real Resend key + rejected recipient): register → **201**, user **created**, resend → **200**, and both failures **logged** (`email send failed (…): Resend send failed: You can only send testing emails to your own email address…`).
- Console-transport happy path: register → 201 + verify token + logged link.
- Server typecheck + eslint pass.

Note: the forced-failure error is exactly the #65 case (Resend test-mode recipient limit) — the key itself is valid.

## Changes
- Harden registration against email-send failures (#67)

Closes #67