### PR TITLE
Close #69 - Play mode: resume an in-progress task

### DIFF
--- a/.changes/unreleased/69-play-mode-resume-an-in-progress.md
+++ b/.changes/unreleased/69-play-mode-resume-an-in-progress.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Changed -->
+- Play mode: resume an in-progress task ([#69](https://github.com/neturely/addiapp/issues/69))

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,15 +1,37 @@
+import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useAuth } from '@/auth/useAuth'
 import { Mascot } from '@/components/Mascot'
+import { fetchTasks, type Task } from '@/lib/tasks'
+
+/** Most recently started task first (falls back to newest id). */
+function mostRecentlyStarted(tasks: Task[]): Task | null {
+  if (tasks.length === 0) return null
+  return [...tasks].sort((a, b) => {
+    const at = a.startedAt ? Date.parse(a.startedAt) : 0
+    const bt = b.startedAt ? Date.parse(b.startedAt) : 0
+    return bt - at || b.id - a.id
+  })[0]
+}
 
 /**
  * Play-mode home screen (issue #29, PROJECT_SPEC §5.1). The mascot-guided entry
  * point: a single "Let's go" leading into the choice screen (#30), plus a
- * secondary "Add a task" (#35). Shares the mascot / coral / spacing language of
- * the choice, task-presented, in-progress and completion screens.
+ * secondary "Add a task" (#35). If a task is mid-flight it surfaces a Resume
+ * affordance (#69) so a started-but-unfinished task isn't stranded — Play-mode
+ * selection only offers backlog tasks, so this is the way back to an active one.
  */
 export function Home() {
   const { user, logout } = useAuth()
+  const [inProgress, setInProgress] = useState<Task[]>([])
+
+  useEffect(() => {
+    fetchTasks('in_progress')
+      .then(setInProgress)
+      .catch(() => undefined) // resume is a bonus; never block the home screen
+  }, [])
+
+  const resume = mostRecentlyStarted(inProgress)
 
   return (
     <main className="relative flex min-h-screen flex-col items-center justify-center gap-6 p-8 text-center">
@@ -17,6 +39,22 @@ export function Home() {
       <h1 className="max-w-md text-3xl font-bold text-gray-800">
         Ready to do something great today?
       </h1>
+
+      {resume && (
+        <div className="flex w-full max-w-sm flex-col items-center gap-1">
+          <Link
+            to={`/play/progress/${resume.id}`}
+            className="flex w-full items-center justify-center gap-2 rounded-xl border-2 border-[#F5A623] bg-[#F5A623]/10 px-6 py-3 font-semibold text-[#a06d00] transition hover:bg-[#F5A623]/20"
+          >
+            ▸ Resume: <span className="max-w-[16rem] truncate">{resume.title}</span>
+          </Link>
+          {inProgress.length > 1 && (
+            <Link to="/dashboard" className="text-xs text-gray-400 underline hover:text-gray-600">
+              {inProgress.length} tasks in progress
+            </Link>
+          )}
+        </div>
+      )}
 
       <div className="mt-2 flex flex-col items-center gap-3">
         <Link


### PR DESCRIPTION
## Summary
Resume an in-progress task from Home — closes the stranding gap found while testing #33.

## Problem
Play-mode selection (#31) only offers backlog tasks, so once you Start something and don't finish it, the in-progress task had no path back (Home had no resume; the in-progress screen's "go home" stranded it).

## Fix
Home now fetches the user's in-progress tasks (`GET /api/tasks?status=in_progress`, #27) and, when any exist, shows a **Resume: <title>** button that routes to `/play/progress/:id` (the #33 screen). It surfaces the **most recently started** task; when more than one is in progress, a small "N tasks in progress" link points to the dashboard (which already has per-row Resume).

## Cardinality
The guided flow implies one active task, but the dashboard can create several — so this handles multiple: resume the latest, link the rest to the dashboard.

## Scope / verification
- Frontend only (Home.tsx); no backend changes — reuses the existing status filter.
- Client typecheck, `vite build`, eslint pass. Verified the endpoint returns id/title/startedAt; with two in-progress tasks the Resume targets the most-recent and the "N in progress" link appears.

## Changes
- Play mode: resume an in-progress task from Home (#69)

Closes #69