### PR TITLE
Close #71 - Documentation sync: fold #25–#70 into CLAUDE.md / PROJECT_SPEC.md

### DIFF
--- a/.changes/unreleased/71-documentation-sync-fold-25-70-into.md
+++ b/.changes/unreleased/71-documentation-sync-fold-25-70-into.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Changed -->
+- Documentation sync: fold #25–#70 into CLAUDE.md / PROJECT_SPEC.md ([#71](https://github.com/neturely/addiapp/issues/71))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,8 +53,8 @@ person/org — confirm or correct.)*
   Brevo for its marketing/contacts/list/automation layer, which AddiApp doesn't
   need — AddiApp is pure transactional, which is exactly Resend's niche. Two
   intentional per-project choices for different needs, not an inconsistency to
-  reconcile. (The email features themselves — verification #61, password reset
-  #62 — are built on their own branches but **not yet merged to `develop`**.)
+  reconcile. (Email verification #61 and password reset #62 are built and merged;
+  production still needs Resend domain verification for addiapp.com — #65.)
 - Hosting: KnownHost shared hosting — cPanel, CloudLinux, LiteSpeed, Node.js
   Selector (Passenger) for the Express backend; static build served directly
   for the frontend.
@@ -112,9 +112,15 @@ route handler.
 
 ## What's built (maps to PROJECT_SPEC §5/§6)
 
-Merged to `develop` (#25–#38, #69). Quick orientation for a fresh session:
+Merged to `develop` (#25–#38, #61, #62, #69). Quick orientation for a fresh session:
 
-- **Auth (#26)**: register / login / logout / `me`, DB-backed sessions, bcryptjs.
+- **Auth (#26, #61, #62)**: register / login / logout / `me`, DB-backed sessions,
+  bcryptjs. **Email verification** — register creates an unverified account and
+  emails a link (`/api/auth/verify`, `/resend-verification`); login is blocked
+  until verified. **Password reset** — `/api/auth/forgot-password` +
+  `/reset-password` (single-use token, bcrypt, revokes all sessions). Client
+  pages: `/verify`, `/forgot-password`, `/reset`. Email transport +
+  single-use tokens in `server/src/email/` + `email_tokens`.
 - **Task CRUD (#27)**: user-scoped `GET/POST/PATCH/DELETE /api/tasks`, plus
   `GET /api/tasks/next` (selection).
 - **Points (#28)**: `GET /api/points` (lean, for the card) and
@@ -127,8 +133,8 @@ Merged to `develop` (#25–#38, #69). Quick orientation for a fresh session:
 - **Add task (#35)**: `/tasks/new`. **Points card (#37)** on the dashboard.
   **Stats page (#38)**: `/stats`.
 
-NOT yet on `develop`: deploy pipeline (#39), email verification (#61) / password
-reset (#62), marketing homepage (#40, unscoped), user guide (#41, unscoped).
+NOT yet on `develop`: deploy pipeline (#39), marketing homepage (#40, unscoped),
+user guide (#41, unscoped).
 
 ## Repo structure
 
@@ -141,32 +147,33 @@ addiapp/
 ├── .github/workflows/            # (deploy pipeline rewrite is issue #39)
 ├── client/                       # React 19 + Vite SPA (TypeScript)
 │   └── src/
-│       ├── pages/                # Home, Login, Register, Choice, TaskPresented,
+│       ├── pages/                # Home, Login, Register, Verify, ForgotPassword,
+│       │                         #   ResetPassword, Choice, TaskPresented,
 │       │                         #   InProgress, AddTask, EditTask, Dashboard,
 │       │                         #   Stats, NotFound
 │       ├── components/           # Mascot, EmptyState, Completion, PointsCard,
 │       │                         #   TaskForm, ProtectedRoute
 │       ├── auth/                 # AuthProvider, authContext, useAuth
-│       ├── lib/                  # tasks.ts, points.ts (raw-fetch API clients)
+│       ├── lib/                  # api.ts + apiError.ts (apiRequest wrapper),
+│       │                         #   tasks.ts, points.ts (raw-fetch clients)
 │       └── router.tsx
 ├── server/                       # Node.js + Express API (TypeScript)
-│   ├── drizzle/                  # generated SQL migrations
+│   ├── drizzle/                  # generated SQL migrations (0000–0002)
 │   └── src/
 │       ├── db/                   # Drizzle schema, connection, migrator
-│       ├── auth/                 # passwords (bcryptjs), sessions (DB-backed)
+│       ├── auth/                 # passwords (bcryptjs), sessions, emailTokens
+│       ├── email/                # Resend + console transport, templates (#61/#62)
 │       ├── points/              # config.ts (tunables), calculate.ts, award.ts
 │       ├── tasks/                # selection.ts (swappable SelectionStrategy)
 │       ├── routes/               # health, auth, tasks, points
 │       ├── middleware/           # requireAuth
+│       ├── config.ts             # env-sourced runtime config (appUrl, Resend)
 │       └── app.ts / index.ts
 ├── public/fonts/                 # Nunito web fonts (kept from original)
 ├── CLAUDE.md
 ├── PROJECT_SPEC.md
 └── README.md
 ```
-
-(No `server/src/email/` on `develop` — the Resend integration lives on the
-unmerged #61/#62 branches.)
 
 ## Local dev environment
 
@@ -217,9 +224,11 @@ locked as final brand palette.
 - Express: standard REST conventions; route handlers stay thin, business logic
   lives in modules (`points/`, `tasks/selection.ts`).
 - DB access via **Drizzle ORM** (parameterized) — no raw string concatenation.
-- Client API calls: plain `fetch` with `credentials: 'include'` in
-  `client/src/lib/*` (a shared api wrapper arrives with #61; until then, match
-  the raw-fetch idiom).
+- Client API calls: a shared `apiRequest` wrapper (`client/src/lib/api.ts`, from
+  #61) that sends cookies and throws `ApiError` — the auth pages use it. The
+  older Play-mode clients (`lib/tasks.ts`, `lib/points.ts`) still use plain
+  `fetch` with `credentials: 'include'`; unifying them onto `apiRequest` is a
+  future cleanup, not required.
 - **Zod** validates request bodies/queries server-side; the client mirrors the
   same rules for fast feedback, but the server is authoritative.
 - Environment variables via `.env` (never committed).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,10 @@
 # AddiApp — Project Context
 
-> Draft starter instructions, built from the rebuild-planning conversation as of
-> 2026-07-11. This is a NEW project (rebuild from scratch) — much less is
-> settled than a mature project's CLAUDE.md. Sections marked **TBD** need a
-> decision before they can be treated as fixed. Update this file as decisions
-> land; treat it the same way wptips.com's CLAUDE.md is treated — the
-> authoritative reference that supersedes stale chat history.
+> Authoritative project reference — supersedes stale chat history. Originally a
+> rebuild-planning draft (2026-07-11); synced 2026-07-12 to fold in the merged
+> work #25–#70 (see "What's built" below). Most core decisions are now settled;
+> remaining open items live in the Open decisions log. Where this file and the
+> code disagree, the code (on `develop`) wins — update this file to match.
 
 ## What this project is
 
@@ -40,9 +39,22 @@ person/org — confirm or correct.)*
   Router doesn't fit KnownHost shared hosting + FTP deploy well.
 - Database: MySQL/MariaDB — not Postgres, not Supabase. Not available on
   shared cPanel plans.
-- Auth: custom, self-rolled (sessions or JWT + bcrypt). Not Supabase Auth,
-  not Auth.js/NextAuth.
-- Styling: Tailwind CSS.
+- DB access: **Drizzle ORM** (+ `mysql2` driver) — decided. Schema in
+  `server/src/db/schema.ts`; generated SQL migrations in `server/drizzle/`.
+- Auth: custom, self-rolled — **DB-backed server-side sessions** (opaque random
+  token in an httpOnly `sid` cookie, 7-day TTL; the `sessions` row is the source
+  of truth, so logout/expiry revoke access immediately) + **bcryptjs** password
+  hashing (pure-JS, no native addon to compile on shared hosting). Sessions,
+  **not JWT**. Not Supabase Auth, not Auth.js/NextAuth.
+- Styling: Tailwind CSS v4 (utility classes, no config file; coral brand accents
+  as arbitrary values like `bg-[#D85A30]`).
+- Transactional email: **Resend** (TypeScript SDK, `RESEND_API_KEY`) for the
+  verification + password-reset emails. Deliberately NOT Brevo: wptips.com uses
+  Brevo for its marketing/contacts/list/automation layer, which AddiApp doesn't
+  need — AddiApp is pure transactional, which is exactly Resend's niche. Two
+  intentional per-project choices for different needs, not an inconsistency to
+  reconcile. (The email features themselves — verification #61, password reset
+  #62 — are built on their own branches but **not yet merged to `develop`**.)
 - Hosting: KnownHost shared hosting — cPanel, CloudLinux, LiteSpeed, Node.js
   Selector (Passenger) for the Express backend; static build served directly
   for the frontend.
@@ -61,16 +73,62 @@ person/org — confirm or correct.)*
 - Release strategy: build a minimal Release 1, defer competitive/social
   features (leaderboards, teams, projects, sharing) to later phases.
 
-## Points / gamification system
+## Points / gamification system (finalized, #28)
 
-- Base points by complexity (set at task creation): Low = 2, Medium = 5, High = 10
-- Estimated time: user enters manually at task creation (minutes) — deliberately
-  not auto-calculated from complexity, since they don't reliably correlate
-- Speed bonus: awarded when actual completion time < estimated time, scaled
-  to how much faster (not flat) — **exact formula/curve TBD**
-- Daily multiplier: grows per task completed that day, shown live (e.g.
-  "current bonus: 1.3x"), resets at midnight, confirmed capped — **cap value
-  TBD (placeholder 2.0x)**, **growth rate per task TBD (placeholder +0.1x)**
+All numbers are FINAL and live in ONE file — `server/src/points/config.ts`.
+Tuning them never touches the pure math (`points/calculate.ts`) or the award
+orchestration (`points/award.ts`). See PROJECT_SPEC §7 for the full formulas.
+
+- Base points: Low = 2, Medium = 5, High = 10.
+- Estimated time: entered manually at creation (minutes); not derived from
+  complexity.
+- Speed bonus (saturation-based, anti-gaming): scales with time saved, reaching
+  the ceiling of **+100% of base** (`SPEED_BONUS_MAX_RATIO = 1.0`) at
+  **≤50% of the estimate** (`SPEED_BONUS_SATURATION = 0.5`); 0 if on/over
+  estimate. No extra beyond saturation.
+- Daily multiplier: `min(1 + (n−1)·0.15, 2.0)` for the n-th completion of the
+  day (`GROWTH = 0.15`, `CAP = 2.0`) → cap reached at the **8th** task/day;
+  resets at midnight in `APP_TIMEZONE` (default **Europe/Stockholm**). Shown live
+  as the next task's multiplier. Total = `round((base + speedBonus) × multiplier)`.
+- Idempotency: points are awarded **once per task, ever** (first completion) —
+  reopening + re-completing does NOT re-award (the `points_log` ledger is checked
+  by `task_id`).
+- Points are shown up front (approximate base, before commitment) — decided.
+
+## Task-selection algorithm (Play mode, #31)
+
+Behind a swappable interface in `server/src/tasks/selection.ts`
+(`SelectionStrategy = (candidates, rng?) => Task | null`). The route
+(`GET /api/tasks/next`) filters candidates (win-type → complexity: small =
+{low, medium}, big = {medium, high}; time-available; backlog only; optional
+`exclude` for re-roll); the strategy only picks one — no selection logic in the
+route handler.
+
+- Default: **`weightedByAge`** — weighted random favouring older tasks
+  (rank-based weights; oldest most likely, still random) for the "keep momentum"
+  feel. Alternates `oldestFirst` / `uniformRandom` ship too.
+- A future **per-user selection preference** is designed for (swap
+  `strategies[user.preference]`) but **not built** — no settings page exists yet.
+
+## What's built (maps to PROJECT_SPEC §5/§6)
+
+Merged to `develop` (#25–#38, #69). Quick orientation for a fresh session:
+
+- **Auth (#26)**: register / login / logout / `me`, DB-backed sessions, bcryptjs.
+- **Task CRUD (#27)**: user-scoped `GET/POST/PATCH/DELETE /api/tasks`, plus
+  `GET /api/tasks/next` (selection).
+- **Points (#28)**: `GET /api/points` (lean, for the card) and
+  `GET /api/points/stats` (lifetime + streak, for the stats page).
+- **Play mode (#29–#34, #69)**: Home `/`, Choice `/play`, Task `/play/task`,
+  In-progress `/play/progress/:id`, Completion, Empty state, Resume-from-home.
+- **Dashboard (#36)**: `/dashboard` — table + inline edit (title/complexity/est/
+  status), full edit page `/tasks/:id/edit` (shared `TaskForm` with Add), status
+  filter tabs, per-row Start/Resume/Edit/Delete, undo-toast delete.
+- **Add task (#35)**: `/tasks/new`. **Points card (#37)** on the dashboard.
+  **Stats page (#38)**: `/stats`.
+
+NOT yet on `develop`: deploy pipeline (#39), email verification (#61) / password
+reset (#62), marketing homepage (#40, unscoped), user guide (#41, unscoped).
 
 ## Repo structure
 
@@ -79,17 +137,36 @@ Monorepo (npm workspaces) — **decided**. Client and server in one repo.
 ```
 addiapp/
 ├── docker-compose.yml            # local MySQL 8.0 for development
-├── .github/workflows/            # auto-assign (deploy pipeline is issue #39)
-├── client/                       # React + Vite SPA (TypeScript)
+├── scripts/db.sh                 # db:up/down/reset helper (macOS vs Linux compose)
+├── .github/workflows/            # (deploy pipeline rewrite is issue #39)
+├── client/                       # React 19 + Vite SPA (TypeScript)
 │   └── src/
+│       ├── pages/                # Home, Login, Register, Choice, TaskPresented,
+│       │                         #   InProgress, AddTask, EditTask, Dashboard,
+│       │                         #   Stats, NotFound
+│       ├── components/           # Mascot, EmptyState, Completion, PointsCard,
+│       │                         #   TaskForm, ProtectedRoute
+│       ├── auth/                 # AuthProvider, authContext, useAuth
+│       ├── lib/                  # tasks.ts, points.ts (raw-fetch API clients)
+│       └── router.tsx
 ├── server/                       # Node.js + Express API (TypeScript)
 │   ├── drizzle/                  # generated SQL migrations
-│   └── src/db/                   # Drizzle schema, connection, migrator
+│   └── src/
+│       ├── db/                   # Drizzle schema, connection, migrator
+│       ├── auth/                 # passwords (bcryptjs), sessions (DB-backed)
+│       ├── points/              # config.ts (tunables), calculate.ts, award.ts
+│       ├── tasks/                # selection.ts (swappable SelectionStrategy)
+│       ├── routes/               # health, auth, tasks, points
+│       ├── middleware/           # requireAuth
+│       └── app.ts / index.ts
 ├── public/fonts/                 # Nunito web fonts (kept from original)
 ├── CLAUDE.md
 ├── PROJECT_SPEC.md
 └── README.md
 ```
+
+(No `server/src/email/` on `develop` — the Resend integration lives on the
+unmerged #61/#62 branches.)
 
 ## Local dev environment
 
@@ -118,42 +195,34 @@ addiapp/
   `ln -sf "$(brew --prefix docker)/bin/docker" /opt/homebrew/bin/docker` then
   `colima start`.
 
-## Screens designed so far (mockups only, not built)
+## Screens (built)
 
-"Play" mode (mascot-guided home):
-1. Home — mascot + "Ready to do something great today?" + "Let's go" CTA +
-   secondary link to Dashboard
-2. Choice screen — "What kind of win do you want?" (small/quick vs
-   big/effort) + time-available filter
-3. Task presented — one task shown with title, time, tag, points; Start
-   (→ in-progress) or "Give me something else" (re-roll)
-4. Empty state — mascot + "Nothing here right now" + "Add a task" CTA +
-   Dashboard link
-
-Not yet designed: task in-progress screen, task completion/celebration
-screen, add-task form, dashboard layout, user points page, dashboard user
-card, marketing homepage, user guide.
+All Play-mode and dashboard screens are implemented and merged to `develop`
+(#29–#38, #69) — see "What's built" above and PROJECT_SPEC §5/§6. The only
+screens still not designed/built are the marketing/landing homepage (#40) and
+the user guide/help content (#41) — both unscoped.
 
 Mascot: placeholder simple flat character only (used consistently across all
-mockups so far). Real mascot art + expression variations is a deliberate
-later design pass, likely in Claude Design once the UX flow is locked.
+screens). Real mascot art + expression variations is a deliberate later design
+pass, likely in Claude Design once the UX flow is locked.
 
 Color palette used in mockups: warm coral primary (`#D85A30`), supporting
 teal/amber/purple for badges/tags — not a literal Duolingo green, not yet
 locked as final brand palette.
 
-## Coding standards — TBD, draft defaults
+## Coding standards
 
-- TypeScript on both client and server (matches the old project's direction;
-  not yet explicitly re-confirmed for the rebuild)
-- React functional components + hooks, no class components
-- Express: standard REST conventions, route handlers separated from business
-  logic
-- MySQL: use a query builder or lightweight ORM rather than raw string
-  concatenation (specific choice not yet made — e.g. `mysql2` directly with
-  parameterized queries vs. Prisma/Drizzle) — **needs a decision**
-- Environment variables via `.env` (never committed) — mirrors old project's
-  `.env.local` convention
+- TypeScript on both client and server — confirmed.
+- React functional components + hooks, no class components.
+- Express: standard REST conventions; route handlers stay thin, business logic
+  lives in modules (`points/`, `tasks/selection.ts`).
+- DB access via **Drizzle ORM** (parameterized) — no raw string concatenation.
+- Client API calls: plain `fetch` with `credentials: 'include'` in
+  `client/src/lib/*` (a shared api wrapper arrives with #61; until then, match
+  the raw-fetch idiom).
+- **Zod** validates request bodies/queries server-side; the client mirrors the
+  same rules for fast feedback, but the server is authoritative.
+- Environment variables via `.env` (never committed).
 
 ## Deployment — TBD, key open question
 
@@ -192,18 +261,35 @@ locked as final brand palette.
 - Never assume SSH is available on the shared plan until confirmed — deploy
   suggestions should account for FTP-only as the safe default until this is
   resolved
+- Never "fix" AddiApp to use Brevo for consistency with wptips.com — AddiApp
+  uses Resend for transactional email by deliberate choice; they are
+  intentionally different providers for different needs.
+- Never switch auth to JWT or a client-stored token — it's DB-backed sessions
+  (opaque httpOnly `sid` cookie) by decision, so logout/expiry revoke immediately.
+- Never inline task-selection logic into the route — it lives behind the
+  `SelectionStrategy` interface (`server/src/tasks/selection.ts`) so a per-user
+  preference stays a one-line swap.
+- Never hardcode points numbers outside `server/src/points/config.ts` — that's
+  the single source; the client reads base points from `GET /api/points`.
 
 ## Open decisions log
 
-- [ ] SSH availability on KnownHost shared plan
-- [ ] Speed bonus formula/curve
-- [ ] Daily multiplier cap value and growth rate per task
-- [x] Monorepo vs split repos for client/server — **monorepo** (npm workspaces)
-- [x] Query builder / ORM choice for MySQL — **Drizzle ORM** (+ mysql2)
-- [ ] Task in-progress / completion screen design
-- [ ] Add-task form design
-- [ ] Dashboard layout
-- [ ] Marketing homepage and user guide scope
-- [ ] Final color palette / brand direction
-- [ ] Release 1 scope confirmation
-- [ ] Dev environment confirmation (Mac/WSL2/Docker/Claude Code — assumed from wptips.com)
+Resolved items removed in the 2026-07-12 sync. Genuinely still open:
+
+- [ ] Node.js version to target on KnownHost (Passenger / Node.js Selector)
+- [ ] SSH availability on KnownHost shared plan (drives backend deploy — #39)
+- [ ] Marketing / landing homepage scope (#40)
+- [ ] User guide / help content scope (#41)
+- [ ] Production email readiness — Resend domain verification for addiapp.com (#65)
+- [ ] Signup rate-limiting / auth abuse protection
+- [ ] Privacy policy / Terms of Service pages
+- [ ] Home secondary-link set (Add task / Dashboard / Stats) — right long-term
+  set vs. a single Dashboard entry (noted at #29's merge)
+- [ ] Final color palette / brand direction (placeholder warm coral in use)
+- [ ] Real mascot art (placeholder flat character in use)
+- [x] Monorepo vs split repos — **monorepo** (npm workspaces)
+- [x] Query builder / ORM — **Drizzle ORM** (+ mysql2)
+- [x] Auth model — **DB-backed sessions + bcryptjs** (not JWT)
+- [x] Speed-bonus formula, daily-multiplier cap/growth — **finalized** (§7)
+- [x] Task-selection algorithm — **weighted-random, swappable strategy**
+- [x] In-progress / completion / add-task / dashboard designs — **built**

--- a/PROJECT_SPEC.md
+++ b/PROJECT_SPEC.md
@@ -1,6 +1,7 @@
 # AddiApp — Rebuild Project Spec
 
-Living document. Updated as decisions are made. Last updated: 2026-07-11.
+Living document. Updated as decisions are made. Last updated: 2026-07-12
+(batched documentation sync folding in issues #25–#70; see §11).
 
 ## 1. Overview
 
@@ -21,23 +22,33 @@ Chosen specifically to fit **KnownHost shared hosting** (cPanel, CloudLinux,
 LiteSpeed, Node.js Selector via Passenger, MySQL/MariaDB — no root/SSH
 confirmed yet, FTP-based deploy via GitHub Actions).
 
-- **Frontend**: React + Vite, static build (SPA, client-side routing via
-  React Router). No Next.js — SSR/App Router doesn't fit shared hosting +
+- **Frontend**: React 19 + Vite, static build (SPA, client-side routing via
+  React Router v7). No Next.js — SSR/App Router doesn't fit shared hosting +
   FTP deploy well.
-- **Backend**: Node.js + Express, run via cPanel's "Setup Node.js App"
-  (Passenger).
-- **Database**: MySQL/MariaDB (not Postgres — not available on shared
-  cPanel plans).
-- **Auth**: custom, self-rolled (sessions or JWT + bcrypt). Not Supabase
-  Auth, not Auth.js/NextAuth (Auth.js is tightly coupled to Next.js API
-  routes).
-- **Styling**: Tailwind CSS.
-- **Deploy**: GitHub Actions. Static frontend build synced via FTP;
-  Express backend deploy mechanism still TBD (FTP alone doesn't restart a
-  Node process — need to confirm SSH availability on the shared plan).
+- **Backend**: Node.js + Express (TypeScript), run via cPanel's "Setup Node.js
+  App" (Passenger).
+- **Database**: MySQL/MariaDB (not Postgres — not available on shared cPanel
+  plans). Local dev uses a MySQL 8.0 Docker container.
+- **DB access layer**: **Drizzle ORM** (+ `mysql2` driver) — *resolved*. Schema
+  in `server/src/db/schema.ts`; generated SQL migrations in `server/drizzle/`.
+- **Auth**: custom, self-rolled — **DB-backed server-side sessions** (opaque
+  random token in an httpOnly `sid` cookie, 7-day TTL, the `sessions` row is the
+  source of truth so logout/expiry revoke immediately) + **bcryptjs** password
+  hashing (pure-JS, no native build to compile on shared hosting). *Resolved:
+  sessions, not JWT.* Not Supabase Auth, not Auth.js/NextAuth.
+- **Styling**: Tailwind CSS v4 (via `@tailwindcss/vite`, no config file —
+  utility classes; brand accents used as arbitrary values, e.g. `bg-[#D85A30]`).
+- **Transactional email**: **Resend** (TypeScript SDK, `RESEND_API_KEY`) —
+  *decided provider* for verification + password-reset. Deliberately NOT Brevo
+  (see CLAUDE.md for the reasoning). Note: the email features themselves
+  (verification #61, password reset #62) are implemented on their own branches
+  but are **not yet merged to `develop`** — they are not part of this release.
+- **Deploy**: GitHub Actions. Static frontend build synced via FTP; Express
+  backend deploy mechanism still open (FTP alone doesn't restart a Node
+  process — need to confirm SSH availability on the shared plan).
 
-Open question: confirm whether SSH is available on the KnownHost shared
-plan, since that changes how the Express app gets deployed/restarted.
+Still open (see §10): Node.js version to target on KnownHost (Passenger),
+SSH availability on the shared plan (drives backend deploy/restart).
 
 ## 3. Domain / infra (confirmed)
 
@@ -67,112 +78,180 @@ plan, since that changes how the Express app gets deployed/restarted.
 
 ## 5. Core UX flow — "Play" mode (mascot-guided home)
 
-Screens designed so far (mockups built in chat, not yet as real
-components):
+**Status: all Play-mode screens are BUILT** (issues #29–#34, #69), not just
+mocked. They share one mascot / coral / spacing language. The flow:
 
-1. **Home** — mascot + "Ready to do something great today?" + single
-   "Let's go" primary CTA. Secondary link to Dashboard.
-2. **Choice screen** — "What kind of win do you want?" → Something small
-   (quick win, low effort) vs Something big (real progress, bigger
-   effort). Time available is also a filter input here.
-3. **Task presented** — algorithm picks ONE task matching the chosen
-   filters. Shows title, estimated time, small/big tag, and points
-   (approximate/shown up front, not hidden — see §6 on why). Primary
-   action: **Start** (moves task to in-progress). Secondary: "Give me
-   something else" (re-roll).
-4. **Empty state** — if no tasks match/exist: mascot + "Nothing here
-   right now" + "Add a task" primary CTA + link to Dashboard.
+1. **Home** (#29, `/`) — mascot + "Ready to do something great today?" + single
+   "Let's go" primary CTA into the choice screen. Secondary links: "Add a task"
+   (#35), "Dashboard" (#36), "Stats" (#38). If a task is mid-flight it also
+   shows a **Resume** affordance (#69, see below).
+2. **Choice screen** (#30, `/play`) — "What kind of win do you want?" →
+   Something small (quick/low effort) vs Something big (real progress). A
+   time-available filter (preset chips) sits alongside. Selections are carried
+   to the task screen as URL params.
+3. **Task presented** (#31, `/play/task`) — the selection algorithm (see below)
+   picks ONE matching backlog task. Shows title, estimated time, effort tag, and
+   approximate base points (shown up front per §7). Primary **Start** → moves the
+   task to in-progress. Secondary "Give me something else" re-rolls, excluding
+   the just-shown task.
+4. **In-progress** (#33, `/play/progress/:id`) — a live count-up timer derived
+   from the server's `startedAt` (survives refresh) plus a speed-bonus meter
+   against the estimate. **Complete** → done (awards points, §7).
+5. **Completion / celebration** (#34) — mascot + confetti-dot accents, "Nice
+   work!", the TOTAL points earned (large, primary), and the current daily
+   multiplier as brief context. **Keep going** skips the choice screen and offers
+   another task reusing the same win/time filters; **Back to home** returns Home.
+6. **Empty state** (#32) — when selection returns nothing: mascot + "Nothing
+   here right now". Primary action is "Add a task" when the backlog is empty, or
+   "Pick a different win" when filters just matched nothing.
 
-Not yet designed:
-- Task in-progress screen (what does "in progress" look like/do?)
-- Task completion screen (celebration moment — this is a key
-  gamification beat, mascot should react here)
-- Add-task form itself
+**Resume (#69)**: because Play-mode selection only offers *backlog* tasks, a
+started-but-unfinished task would otherwise be stranded. Home surfaces the most
+recently started in-progress task as a "Resume: <title>" link to
+`/play/progress/:id`; when more than one is in progress, a small "N tasks in
+progress" link points to the Dashboard. This is an extension of the original
+four-screen flow.
 
-**Requirement**: this entire flow (choice → task → start) must also be
-usable from the Dashboard in a denser, manual form — Dashboard users
-shouldn't be locked out of the game loop, just given a less guided
-version of it.
+### Task-selection algorithm (resolved — was §10's oldest open item)
 
-## 6. Dashboard (admin view)
+Lives behind a swappable interface in `server/src/tasks/selection.ts`:
 
-Clean, Todoist/Linear-style. Purpose: add/edit/list all tasks, manage
-backlog, see everything at once (not one-at-a-time like Play mode).
+```ts
+type SelectionStrategy = (candidates: Task[], rng?: () => number) => Task | null
+```
 
-Confirmed requirements:
-- Add task form (title, complexity, estimated time — see §7)
-- Full task list/management
-- User card showing points (see §7) — dashboard-level summary
-- Same task-selection flow available here in dense/manual form
+- The route (`GET /api/tasks/next`) does the **filtering** — win-type → complexity
+  (`small` = {low, medium}, `big` = {medium, high}; medium is in both pools so the
+  guided flow rarely dead-ends), time-available (`estimatedMinutes ≤ minutes`),
+  status = backlog, and an optional `exclude` id for re-roll. The **strategy** only
+  picks one from the filtered candidates — no selection logic inlined in the route.
+- **Default strategy: `weightedByAge`** — weighted random favouring older tasks
+  (rank-based weights: oldest heaviest, still random). Chosen for the "keep
+  momentum" feel: nothing rots at the bottom of the backlog, but a re-roll still
+  feels fresh (vs. pure random re-offering, or strict oldest-first reading like a
+  to-do list). Rank-based weights keep the function pure/deterministically
+  testable. Alternates `oldestFirst` and `uniformRandom` also ship.
+- A **future per-user selection preference** is designed for — becoming
+  `strategies[user.preference]` is a one-line change — but is **not built** (no
+  settings page exists yet).
 
-Not yet designed: actual layout (list vs table vs cards), filtering/
-sorting, editing UX.
+**Requirement (met)**: this flow is also usable from the Dashboard in a denser,
+manual form — per-row **Start** on the Dashboard is the manual selection entry
+point, so Dashboard users aren't locked out of the game loop.
 
-## 7. Points / gamification system
+## 6. Dashboard (admin view) — BUILT (#36–#38)
 
-**Status: core formula partially decided, two open numbers flagged
-below.**
+Clean, Todoist/Linear-style. Add/edit/list all tasks, manage the backlog, see
+everything at once (not one-at-a-time like Play mode).
 
-- **Base points by complexity** (set at task creation):
-  - Low = 2 pts
-  - Medium = 5 pts
-  - High = 10 pts
-- **Estimated time**: user enters manually at task creation (minutes).
-  Deliberately not auto-calculated from complexity, since complexity and
-  time don't reliably correlate (a "complex" task might only take 15
-  min).
-- **Speed bonus**: awarded when actual completion time < estimated time.
-  Scaled to how much faster the user finishes (not a flat bonus) — e.g.
-  finishing in half the estimated time earns more bonus than finishing
-  10% early. **Exact formula/curve not yet defined — needs a follow-up
-  decision.**
-- **Daily multiplier**: grows with each task completed in a day (e.g.
-  +0.1x per task), shown live in the UI (e.g. "current bonus: 1.3x"),
-  resets at midnight. **Confirmed: capped**, but the actual cap value is
-  still a placeholder (2.0x) — needs a real number.
-- **Points are shown up front** (approximate, before the user commits to
-  a task) — not hidden until completion. Decided explicitly: visibility
-  is motivating, and the speed bonus rewards finishing fast rather than
-  the reward itself being a surprise.
+**Task list / management (#36, `/dashboard`)**:
+- A dense **table** with **status filter tabs** (All / Backlog / In progress /
+  Done, with counts).
+- **Inline edit** of the four column fields (title, complexity, estimated
+  minutes, status) — click a row to edit in place; only changed fields are
+  PATCHed (an unchanged status doesn't re-trigger transition side effects).
+- A per-row **Edit** action opens a **full edit page** (`/tasks/:id/edit`) — the
+  structural home for fields beyond the table's columns (categories, tags, due
+  dates, priorities) as those land. Today its field set matches the inline set. A
+  shared `TaskForm` component backs both the Add form (#35) and this Edit page.
+- Per-row actions: **Start** (backlog → in-progress screen; the manual selection
+  entry), **Resume** (in-progress → #33), **Edit**, **Delete**.
+- **Delete uses an undo toast**, not a confirm dialog: the row disappears
+  immediately and the actual API DELETE is deferred (~5s); "Undo" cancels the
+  pending timer. Fits the fast inline-edit model; fail-safe (navigating away in
+  the window leaves the task). Header has **Play** and **Add task** buttons.
 
-**Where points are displayed**: a user page (points/stats, dedicated
-screen) and a user card on the Dashboard (points summary at a glance).
-Both are confirmed as needed; neither is designed yet.
+**Add-task form (#35, `/tasks/new`)**: title, complexity (segmented picker
+showing base points up front), estimated minutes. Validation mirrors the CRUD
+rules (§ below). Reachable from the empty state, Home, and the Dashboard.
 
-**Open decisions to resolve:**
-1. Exact speed-bonus formula/curve (how "how early" maps to bonus %).
-2. Daily multiplier cap value (currently placeholder 2.0x).
-3. Daily multiplier growth rate per task (currently placeholder +0.1x —
-   confirm or adjust).
+**User points card (#37)**: at the top of the Dashboard — lifetime **total
+points**, current **live daily multiplier**, and **today's** points + tasks.
+Reads `GET /api/points`; refreshes as tasks complete. Links to the stats page.
+
+**User stats page (#38, `/stats`)**: dedicated at-a-glance screen — total points
+(hero) + stat tiles for **lifetime tasks completed**, **day streak** (consecutive
+days with ≥1 completion in the app timezone), **total speed bonus earned**, and
+the **current daily multiplier**, plus today's summary. Reads a richer
+`GET /api/points/stats` (kept separate from the card's lean endpoint).
+
+## 7. Points / gamification system — FINALIZED (#28)
+
+All numbers are final and live in **one file, `server/src/points/config.ts`** —
+tuning them after real usage never touches the calculation logic
+(`server/src/points/calculate.ts`, pure math) or the award orchestration
+(`server/src/points/award.ts`, DB writes). Base points are also surfaced to the
+UI via `GET /api/points` so the front end never hardcodes them.
+
+- **Base points by complexity** (set at task creation): Low = 2, Medium = 5,
+  High = 10.
+- **Estimated time**: user enters manually at task creation (minutes) —
+  deliberately not derived from complexity, since they don't reliably correlate.
+- **Speed bonus** — rewards finishing faster than estimated, scaled to time
+  saved (saturation-based, anti-gaming):
+  - `saved = clamp((estimated − actual) / estimated, 0, 1)`
+  - `effective = min(saved / SPEED_BONUS_SATURATION, 1)` with
+    `SPEED_BONUS_SATURATION = 0.5`
+  - `speedBonus = round(basePoints × SPEED_BONUS_MAX_RATIO × effective)` with
+    `SPEED_BONUS_MAX_RATIO = 1.0`
+  - So: finishing in **≤50% of the estimate** earns the ceiling (**+100% of base
+    points**); finishing exactly on/over the estimate earns 0; in between scales
+    linearly. Beyond 50% faster gives no extra (a wild underestimate can't farm
+    points). *Worked example:* a High task (base 10), estimated 30 min, done in
+    15 min → saved 0.5 → effective 1.0 → speed bonus = 10.
+- **Daily multiplier** — grows with each task completed that day, capped, resets
+  at midnight in the app timezone:
+  - `multiplier(n) = min(1 + (n − 1) × DAILY_MULTIPLIER_GROWTH, DAILY_MULTIPLIER_CAP)`
+    with `GROWTH = 0.15`, `CAP = 2.0` → the cap is reached at the **8th** completed
+    task of the day. Shown live in the UI as the value the *next* completion will
+    earn (e.g. "×1.30 today").
+- **Total for a completion**: `round((basePoints + speedBonus) × multiplier)`.
+  *Worked example continuing the above, as the 3rd task of the day:*
+  `multiplier(3) = 1.30`, total = `round((10 + 10) × 1.30) = 26`.
+- **Timezone**: `APP_TIMEZONE` defaults to **`Europe/Stockholm`** (env-overridable);
+  its midnight resets the daily multiplier / rolls the daily stats.
+- **Idempotency**: points are awarded **exactly once per task, ever** — on its
+  first completion. Re-opening a done task and completing it again does **not**
+  re-award (the `points_log` ledger is checked by `task_id`).
+- **Points are shown up front** (approximate base, before commitment) — decided
+  explicitly: visibility is motivating; the speed bonus rewards finishing fast
+  rather than the reward being a surprise.
+
+The `points_log` ledger stores the award *components* (base / speed bonus /
+multiplier / total) per completion, and `daily_stats` is the per-user/day rollup
+that drives the multiplier — so the formula can be retuned without a schema
+change.
 
 ## 8. Release scope
 
-**Decided**: build a genuinely minimal first release, then branch
-everything else into later phases. Full reconciliation of "what's in
-release 1" is still pending — draft split below, to be refined together.
+**Decided**: a genuinely minimal first release. Reconciled against what's now
+actually built and merged to `develop`.
 
-### Release 1 (draft — needs confirmation)
-- Custom auth (register/login, bcrypt + sessions or JWT)
-- Task CRUD (title, complexity, estimated time)
-- Points system as defined in §7 (with the open numbers resolved)
-- Play mode flow: Home → choice → task presented → start → complete
-  (celebration screen still needs designing)
-- Dashboard: task list/management + user points card
-- Basic user page showing points/stats
-- Marketing/landing homepage explaining what AddiApp is (separate from
-  the in-app "Play" home) — mentioned as needed, not yet scoped
-- Basic user guide/help content — mentioned as needed, not yet scoped
+### Release 1 — status
+- ✅ Custom auth (register/login/logout, bcryptjs + DB-backed sessions) — #26
+- ✅ Task CRUD, user-scoped (title, complexity, estimated time) — #27
+- ✅ Points system as defined in §7 (all numbers finalized) — #28
+- ✅ Play mode: Home → Choice → Task presented → Start → In-progress →
+  Completion, plus Empty state and Resume — #29–#34, #69
+- ✅ Task-selection algorithm (weighted-random, swappable) — part of #31
+- ✅ Dashboard: task list/management + inline edit + full edit page — #36
+- ✅ Dashboard user points card — #37
+- ✅ User points/stats page — #38
+- ⬜ **Marketing / landing homepage** (#40) — the only remaining Release-1 item
+  on the app itself; **not yet scoped**.
+- ⬜ **Basic user guide / help content** (#41) — **not yet scoped**.
+- ◻ Deploy pipeline (GitHub Actions build + FTP + Express restart) — #39, open;
+  transactional email (Resend): verification #61 / reset #62 built on branches,
+  **not yet merged**.
 
 ### Explicitly deferred to later releases
 - Multi-user competitive features: leaderboards, scoreboard
-- Projects (grouping tasks)
-- Teams
-- Issue/task sharing for bonus points
+- Projects (grouping tasks), Teams, task sharing for bonus points
+- Per-user task-selection preference + settings page (interface is ready)
 - Real mascot art + expression variations (placeholder used in v1)
-- Anything else from the old `OLD_SPEC.md` roadmap not listed above
-  (categories, tags, due dates, recurring tasks, attachments,
-  notifications, dark mode, search, filtering, drag & drop, PWA/offline,
-  audit history, AI-assisted task management)
+- Anything else from `OLD_SPEC.md` not listed above (categories, tags, due
+  dates, recurring tasks, attachments, notifications, dark mode, search,
+  filtering, drag & drop, PWA/offline, audit history, AI-assisted management)
 
 ## 9. Old codebase audit — summary
 
@@ -200,16 +279,32 @@ into the rebuild as code:
 
 ## 10. Open questions log
 
-- [ ] SSH availability on KnownHost shared plan (affects backend deploy)
-- [ ] Speed bonus formula/curve
-- [ ] Daily multiplier cap value
-- [ ] Daily multiplier growth rate per task
-- [ ] Task in-progress screen design
-- [ ] Task completion/celebration screen design
-- [ ] Add-task form design
-- [ ] Dashboard layout (list/table/cards, filtering, sorting)
-- [ ] Marketing homepage scope/content
-- [ ] User guide scope/content
-- [ ] Final color palette / brand direction (mockups used placeholder
-  warm coral, not literal Duolingo green)
-- [ ] Release 1 scope — confirm draft list in §8 is final
+Rewritten in this sync — resolved items removed. Genuinely still open:
+
+- [ ] **Node.js version** to target on KnownHost (Passenger / Node.js Selector).
+- [ ] **SSH availability** on the KnownHost shared plan (drives backend
+  deploy/restart mechanism; assume FTP-only until confirmed). Deploy pipeline
+  rewrite is #39.
+- [ ] **#40 marketing / landing homepage** — scope/content not defined.
+- [ ] **#41 user guide / help content** — scope/content not defined.
+- [ ] **Production email readiness** — Resend domain verification for
+  `addiapp.com` (#65) before the email features (#61/#62) can be relied on in
+  production.
+- [ ] **General signup rate-limiting / abuse protection** on auth endpoints.
+- [ ] **Privacy policy / Terms of Service** pages (needed before public launch).
+- [ ] **Home secondary-link tension** — the original mockup called for a
+  "Dashboard" secondary link; the built Home now carries Add task / Dashboard /
+  Stats. Whether that's the right long-term set (vs. a single Dashboard entry) is
+  an open UX call noted at #29's merge.
+- [ ] Final color palette / brand direction (mockups use placeholder warm coral).
+- [ ] Real mascot art (placeholder flat character in use).
+
+## 11. Change log — documentation sync (2026-07-12)
+
+This spec was last substantively updated at #24 (scaffolding). This pass folds in
+the merged work #25–#70 (schema #25, auth #26, task CRUD #27, points #28, Play
+mode #29–#34, add-task #35, dashboard #36, points card #37, stats #38, resume
+#69) ahead of the `develop → main` promotion. Where docs and code disagreed, code
+won. Not covered here because they are **not merged to `develop`**: deploy
+pipeline (#39), email verification (#61) / password reset (#62), and the
+still-unscoped #40/#41.

--- a/PROJECT_SPEC.md
+++ b/PROJECT_SPEC.md
@@ -31,18 +31,26 @@ confirmed yet, FTP-based deploy via GitHub Actions).
   plans). Local dev uses a MySQL 8.0 Docker container.
 - **DB access layer**: **Drizzle ORM** (+ `mysql2` driver) — *resolved*. Schema
   in `server/src/db/schema.ts`; generated SQL migrations in `server/drizzle/`.
-- **Auth**: custom, self-rolled — **DB-backed server-side sessions** (opaque
-  random token in an httpOnly `sid` cookie, 7-day TTL, the `sessions` row is the
-  source of truth so logout/expiry revoke immediately) + **bcryptjs** password
-  hashing (pure-JS, no native build to compile on shared hosting). *Resolved:
-  sessions, not JWT.* Not Supabase Auth, not Auth.js/NextAuth.
+- **Auth (#26, #61, #62)**: custom, self-rolled — **DB-backed server-side
+  sessions** (opaque random token in an httpOnly `sid` cookie, 7-day TTL, the
+  `sessions` row is the source of truth so logout/expiry revoke immediately) +
+  **bcryptjs** password hashing (pure-JS, no native build). Registration creates
+  an **unverified** account and emails a verification link; **login is blocked
+  until verified** (#61). **Password reset** (#62) emails a single-use token;
+  confirming it sets a new bcrypt password and **revokes all existing sessions**.
+  Endpoints: `/api/auth/{register, login, logout, me, verify,
+  resend-verification, forgot-password, reset-password}`. Sessions, not JWT; not
+  Supabase Auth, not Auth.js/NextAuth.
 - **Styling**: Tailwind CSS v4 (via `@tailwindcss/vite`, no config file —
   utility classes; brand accents used as arbitrary values, e.g. `bg-[#D85A30]`).
-- **Transactional email**: **Resend** (TypeScript SDK, `RESEND_API_KEY`) —
-  *decided provider* for verification + password-reset. Deliberately NOT Brevo
-  (see CLAUDE.md for the reasoning). Note: the email features themselves
-  (verification #61, password reset #62) are implemented on their own branches
-  but are **not yet merged to `develop`** — they are not part of this release.
+- **Transactional email**: **Resend** (TypeScript SDK, `RESEND_API_KEY`; a
+  console transport is used in dev when the key is unset, so the full flow runs
+  locally). Deliberately NOT Brevo (see CLAUDE.md). Powers **email verification
+  (#61)** and **password reset (#62)** — both built and merged. A
+  provider-agnostic `EmailService` lives in `server/src/email/`; single-use
+  tokens live in `email_tokens` (`verify` 24h / `reset` 1h TTL). Production still
+  needs Resend **domain verification** for addiapp.com (#65) before live sends to
+  arbitrary recipients.
 - **Deploy**: GitHub Actions. Static frontend build synced via FTP; Express
   backend deploy mechanism still open (FTP alone doesn't restart a Node
   process — need to confirm SSH availability on the shared plan).
@@ -240,9 +248,8 @@ actually built and merged to `develop`.
 - ⬜ **Marketing / landing homepage** (#40) — the only remaining Release-1 item
   on the app itself; **not yet scoped**.
 - ⬜ **Basic user guide / help content** (#41) — **not yet scoped**.
-- ◻ Deploy pipeline (GitHub Actions build + FTP + Express restart) — #39, open;
-  transactional email (Resend): verification #61 / reset #62 built on branches,
-  **not yet merged**.
+- ✅ Email verification (#61) + password reset (#62) — Resend transactional email.
+- ◻ Deploy pipeline (GitHub Actions build + FTP + Express restart) — #39, open.
 
 ### Explicitly deferred to later releases
 - Multi-user competitive features: leaderboards, scoreboard
@@ -304,7 +311,7 @@ Rewritten in this sync — resolved items removed. Genuinely still open:
 This spec was last substantively updated at #24 (scaffolding). This pass folds in
 the merged work #25–#70 (schema #25, auth #26, task CRUD #27, points #28, Play
 mode #29–#34, add-task #35, dashboard #36, points card #37, stats #38, resume
-#69) ahead of the `develop → main` promotion. Where docs and code disagreed, code
-won. Not covered here because they are **not merged to `develop`**: deploy
-pipeline (#39), email verification (#61) / password reset (#62), and the
-still-unscoped #40/#41.
+#69) ahead of the `develop → main` promotion; a follow-up pass then folded in
+**email verification (#61)** and **password reset (#62)** once they merged. Where
+docs and code disagreed, code won. Still not on `develop`: the deploy pipeline
+(#39) and the unscoped #40/#41.


### PR DESCRIPTION
## Summary
Docs-only sync of CLAUDE.md + PROJECT_SPEC.md folding in merged work #25–#70, ahead of the develop→main promotion. Code on develop is the source of truth. No app code touched.

## PROJECT_SPEC.md
- §2 stack: Drizzle ORM + DB-backed sessions (bcryptjs) marked resolved; Node version + SSH kept open.
- §5 Play mode: rewritten from "mockups" to BUILT (#29–#34), added Resume (#69) and a new **task-selection algorithm** subsection (weighted-random-favouring-older, swappable SelectionStrategy, future per-user setting designed-not-built).
- §6 Dashboard: documented as built — table + inline edit, separate full edit page for future fields, status filter tabs, per-row actions, undo-toast delete; points card (#37) and stats page (#38) contents.
- §7 Points: all placeholders replaced with final numbers (speed bonus MAX_RATIO 1.0 / SATURATION 0.5 with worked example; multiplier GROWTH 0.15 / CAP 2.0, capped at 8 tasks/day; APP_TIMEZONE Europe/Stockholm; award-once idempotency; config at server/src/points/config.ts).
- §8 release scope reconciled (only #40/#41 remain, unscoped); §10 open questions rewritten to only genuinely-open items; new §11 change-log.

## CLAUDE.md
- Decisions: auth (DB-backed sessions + bcryptjs, not JWT), Drizzle, Resend (with the why-not-Brevo note).
- Added: finalized points summary + config location, task-selection algorithm, a "What's built" orientation list, updated repo-structure tree, confirmed coding standards, never-do additions (Brevo, JWT, inline selection, hardcoded points), rewritten open-decisions log.

## Accuracy flag
Email verification (#61) / password reset (#62) are **not merged to develop**, so they're documented as decided-but-unmerged (Resend as the chosen provider) rather than as built — and `server/src/email/` is deliberately absent from the repo tree. This is the one place the task instructions (which mentioned server/src/email/) were reconciled against the actual develop state, code winning.

## Changes
- docs: sync CLAUDE.md + PROJECT_SPEC.md through #25–#70

Closes #71