### PR TITLE
Close #74 - Address promotion-review (#73) findings: forgot-password hardening, logout cookie, award idempotency race, client input guards

### DIFF
--- a/.changes/unreleased/74-address-promotion-review-73-findings-forgot.md
+++ b/.changes/unreleased/74-address-promotion-review-73-findings-forgot.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Added -->
+- Address promotion-review (#73) findings: forgot-password hardening, logout cookie, award idempotency race, client input… ([#74](https://github.com/neturely/addiapp/issues/74))

--- a/client/src/components/PointsCard.tsx
+++ b/client/src/components/PointsCard.tsx
@@ -13,8 +13,14 @@ export function PointsCard({ refreshSignal = 0 }: { refreshSignal?: number }) {
 
   useEffect(() => {
     let cancelled = false
+    setFailed(false) // a refetch can recover from a previous transient failure
     fetchPoints()
-      .then((s) => !cancelled && setStats(s))
+      .then((s) => {
+        if (!cancelled) {
+          setStats(s)
+          setFailed(false)
+        }
+      })
       .catch(() => !cancelled && setFailed(true))
     return () => {
       cancelled = true

--- a/client/src/lib/tasks.ts
+++ b/client/src/lib/tasks.ts
@@ -21,6 +21,15 @@ export type AwardResult = {
 
 export type WinSize = 'small' | 'big'
 
+/**
+ * Parse a `minutes` URL param defensively → a positive integer, else undefined.
+ * Guards against `?minutes=NaN`/junk propagating into API calls and routes.
+ */
+export function parseMinutes(raw: string | null): number | undefined {
+  const n = Number(raw)
+  return Number.isInteger(n) && n > 0 ? n : undefined
+}
+
 /** Fields for creating a task (issue #35 add-task form). */
 export type NewTaskInput = {
   title: string

--- a/client/src/pages/InProgress.tsx
+++ b/client/src/pages/InProgress.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { Mascot } from '@/components/Mascot'
 import { Completion } from '@/components/Completion'
-import { completeTask, getTask, type AwardResult, type Task } from '@/lib/tasks'
+import { completeTask, getTask, parseMinutes, type AwardResult, type Task } from '@/lib/tasks'
 import { fetchPoints, type PointsStats } from '@/lib/points'
 
 function pad(n: number): string {
@@ -35,8 +35,7 @@ export function InProgress() {
   const [params] = useSearchParams()
   const sizeParam = params.get('size')
   const size = sizeParam === 'small' || sizeParam === 'big' ? sizeParam : undefined
-  const minutesParam = params.get('minutes')
-  const minutes = minutesParam ? Number(minutesParam) : undefined
+  const minutes = parseMinutes(params.get('minutes'))
 
   const [task, setTask] = useState<Task | null>(null)
   const [points, setPoints] = useState<PointsStats | null>(null)

--- a/client/src/pages/TaskPresented.tsx
+++ b/client/src/pages/TaskPresented.tsx
@@ -2,7 +2,14 @@ import { useCallback, useEffect, useState } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { Mascot } from '@/components/Mascot'
 import { EmptyState } from '@/components/EmptyState'
-import { fetchNextTask, startTask, type Task, type TaskComplexity, type WinSize } from '@/lib/tasks'
+import {
+  fetchNextTask,
+  parseMinutes,
+  startTask,
+  type Task,
+  type TaskComplexity,
+  type WinSize,
+} from '@/lib/tasks'
 import { fetchPoints, type PointsStats } from '@/lib/points'
 
 const COMPLEXITY_TAG: Record<TaskComplexity, { label: string; className: string }> = {
@@ -31,8 +38,7 @@ function parseSize(raw: string | null): WinSize | undefined {
 export function TaskPresented() {
   const [params] = useSearchParams()
   const size = parseSize(params.get('size'))
-  const minutesParam = params.get('minutes')
-  const minutes = minutesParam ? Number(minutesParam) : undefined
+  const minutes = parseMinutes(params.get('minutes'))
 
   const [task, setTask] = useState<Task | null>()
   const [points, setPoints] = useState<PointsStats | null>(null)

--- a/server/drizzle/0003_parched_next_avengers.sql
+++ b/server/drizzle/0003_parched_next_avengers.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `points_log` ADD CONSTRAINT `points_log_task_id_unique` UNIQUE(`task_id`);

--- a/server/drizzle/meta/0003_snapshot.json
+++ b/server/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,552 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "3204b718-89b3-4df0-a83c-c811a003e09b",
+  "prevId": "2113da67-18fe-4f1d-a7b3-25d120ff0f33",
+  "tables": {
+    "daily_stats": {
+      "name": "daily_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stat_date": {
+          "name": "stat_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tasks_completed": {
+          "name": "tasks_completed",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "points_earned": {
+          "name": "points_earned",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "multiplier": {
+          "name": "multiplier",
+          "type": "decimal(4,2)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'1.00'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "daily_stats_user_id_users_id_fk": {
+          "name": "daily_stats_user_id_users_id_fk",
+          "tableFrom": "daily_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "daily_stats_id": {
+          "name": "daily_stats_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "daily_stats_user_date_unq": {
+          "name": "daily_stats_user_date_unq",
+          "columns": [
+            "user_id",
+            "stat_date"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "email_tokens": {
+      "name": "email_tokens",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('verify','reset')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_tokens_user_id_users_id_fk": {
+          "name": "email_tokens_user_id_users_id_fk",
+          "tableFrom": "email_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "email_tokens_token": {
+          "name": "email_tokens_token",
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "points_log": {
+      "name": "points_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_points": {
+          "name": "base_points",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "speed_bonus": {
+          "name": "speed_bonus",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "multiplier": {
+          "name": "multiplier",
+          "type": "decimal(4,2)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'1.00'"
+        },
+        "total_points": {
+          "name": "total_points",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "awarded_at": {
+          "name": "awarded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "points_log_user_id_users_id_fk": {
+          "name": "points_log_user_id_users_id_fk",
+          "tableFrom": "points_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "points_log_task_id_tasks_id_fk": {
+          "name": "points_log_task_id_tasks_id_fk",
+          "tableFrom": "points_log",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "points_log_id": {
+          "name": "points_log_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "points_log_task_id_unique": {
+          "name": "points_log_task_id_unique",
+          "columns": [
+            "task_id"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "sessions_id": {
+          "name": "sessions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "enum('low','medium','high')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "estimated_minutes": {
+          "name": "estimated_minutes",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('backlog','in_progress','done')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'backlog'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actual_minutes": {
+          "name": "actual_minutes",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_user_id_users_id_fk": {
+          "name": "tasks_user_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tasks_id": {
+          "name": "tasks_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "users_id": {
+          "name": "users_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1783794760422,
       "tag": "0002_overrated_triathlon",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "5",
+      "when": 1783879717186,
+      "tag": "0003_parched_next_avengers",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -81,7 +81,12 @@ export const pointsLog = mysqlTable('points_log', {
   userId: int('user_id')
     .notNull()
     .references(() => users.id, { onDelete: 'cascade' }),
-  taskId: int('task_id').references(() => tasks.id, { onDelete: 'set null' }),
+  // UNIQUE so points are awarded at most once per task even under a concurrent
+  // double-complete race (issue #74). Nullable → MySQL allows many NULLs, so the
+  // onDelete: 'set null' rows don't collide.
+  taskId: int('task_id')
+    .references(() => tasks.id, { onDelete: 'set null' })
+    .unique(),
   basePoints: int('base_points').notNull(),
   speedBonus: int('speed_bonus').notNull().default(0),
   multiplier: decimal('multiplier', { precision: 4, scale: 2 }).notNull().default('1.00'),

--- a/server/src/points/award.ts
+++ b/server/src/points/award.ts
@@ -17,6 +17,13 @@ export type AwardResult = {
   totalPoints: number
 }
 
+/** True for a MySQL duplicate-key (unique constraint) violation. */
+function isDuplicateKeyError(err: unknown): boolean {
+  return (
+    typeof err === 'object' && err !== null && (err as { code?: string }).code === 'ER_DUP_ENTRY'
+  )
+}
+
 /**
  * Awards points for a completed task. Idempotent per task — a task earns points
  * exactly once (its first completion), so re-opening + re-completing does not
@@ -47,14 +54,23 @@ export async function awardTaskCompletion(task: Task): Promise<AwardResult | nul
   // What the *next* completion would earn — the live value shown in the UI.
   const liveMultiplier = dailyMultiplier(n + 1)
 
-  await db.insert(pointsLog).values({
-    userId: task.userId,
-    taskId: task.id,
-    basePoints,
-    speedBonus,
-    multiplier: multiplier.toFixed(2),
-    totalPoints,
-  })
+  // The UNIQUE(task_id) constraint (issue #74) is the real idempotency gate: the
+  // pre-check above is only a fast path. Under a concurrent double-complete this
+  // insert atomically picks the single winner — a duplicate-key means another
+  // request already awarded this task, so bail before touching daily stats.
+  try {
+    await db.insert(pointsLog).values({
+      userId: task.userId,
+      taskId: task.id,
+      basePoints,
+      speedBonus,
+      multiplier: multiplier.toFixed(2),
+      totalPoints,
+    })
+  } catch (err) {
+    if (isDuplicateKeyError(err)) return null
+    throw err
+  }
 
   await db
     .insert(dailyStats)

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -229,7 +229,11 @@ authRouter.post(
     const rows = await db.select().from(users).where(eq(users.email, parsed.data.email)).limit(1)
     const user = rows[0]
     if (user) {
-      await sendPasswordResetEmail(user.id, user.email)
+      // Best-effort so a provider hiccup keeps the same generic 200 (no
+      // enumeration) instead of 500ing (issue #67 pattern).
+      await sendEmailBestEffort(`password reset for user ${user.id} <${user.email}>`, () =>
+        sendPasswordResetEmail(user.id, user.email),
+      )
     }
     res.json({
       message: 'If an account exists for that email, a password reset link has been sent.',
@@ -265,7 +269,14 @@ authRouter.post(
   asyncHandler(async (req, res) => {
     const sid = req.cookies?.[SESSION_COOKIE] as string | undefined
     if (sid) await deleteSession(sid)
-    res.clearCookie(SESSION_COOKIE, { path: '/' })
+    // Clear with the same attributes the cookie was set with, so browsers
+    // reliably remove it (a bare { path } can leave it in place in production).
+    res.clearCookie(SESSION_COOKIE, {
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: config.isProd,
+      path: '/',
+    })
     res.status(204).end()
   }),
 )


### PR DESCRIPTION
## Summary
Remediates all 6 findings from Copilot's review of the develop→main promotion (#73). Lands on develop so #73 updates.

1. **/forgot-password hardening** — wrap the send in `sendEmailBestEffort`; a provider failure now keeps the generic 200 (no enumeration) instead of 500.
2. **logout cookie** — clear `sid` with the same attributes it was set with (`httpOnly`/`sameSite:'lax'`/`secure:isProd`/`path`), so it's reliably removed in production.
3. **award idempotency race** — added `UNIQUE(points_log.task_id)` (migration `0003`) and made the insert race-safe (catch duplicate-key → treat as already-awarded, before touching daily stats). **Verified with 5 concurrent completes → exactly 1 points_log row, awarded once.**
4. **PointsCard** — reset `failed` on each refetch so a transient network error is recoverable within the session.
5/6. **TaskPresented / InProgress** — parse `minutes` via a shared `parseMinutes` (positive integer, else undefined) so `?minutes=NaN` can't propagate into API calls / "Keep going" links.

Verification: server + client typecheck, `vite build`, eslint all pass; race-safety and the forgot-password best-effort path driven end-to-end against MySQL; the other three are cookie-attribute / component-state / pure-parse changes covered by typecheck + build.

## Changes
- Address promotion-review (#73) findings (#74)

Closes #74