### PR TITLE
Close #80 - Rate-limit login + register endpoints (part 1 of #79)

### DIFF
--- a/.changes/unreleased/80-rate-limit-login-register-endpoints-part.md
+++ b/.changes/unreleased/80-rate-limit-login-register-endpoints-part.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Changed -->
+- Rate-limit login + register endpoints (part 1 of #79) ([#80](https://github.com/neturely/addiapp/issues/80))

--- a/api/src/Controllers/AuthController.php
+++ b/api/src/Controllers/AuthController.php
@@ -19,6 +19,11 @@ final class AuthController
     /** POST /register — creates an unverified account and emails a link. No login. */
     public function register(Request $req, array $params): void
     {
+        if (!RateLimit::check('register', $req->clientIp(), 10)) {
+            Response::error('Too many requests, please try again later.', 429);
+            return;
+        }
+
         $email = self::email($req->input('email'));
         $password = $req->input('password');
         $displayName = self::displayName($req->input('displayName'));
@@ -64,6 +69,17 @@ final class AuthController
         $password = $req->input('password');
         if ($email === null || !is_string($password) || $password === '') {
             Response::error('Invalid credentials', 400);
+            return;
+        }
+
+        // Throttle before the (expensive) bcrypt verify: per-IP catches one host
+        // brute-forcing, per-email catches distributed targeting of one account.
+        // Fires regardless of whether the account exists (no enumeration).
+        if (
+            !RateLimit::check('login-ip', $req->clientIp(), 20)
+            || !RateLimit::check('login-email', $email, 10)
+        ) {
+            Response::error('Too many login attempts, please try again later.', 429);
             return;
         }
 

--- a/api/src/RateLimit.php
+++ b/api/src/RateLimit.php
@@ -11,9 +11,11 @@ namespace App;
  */
 final class RateLimit
 {
-    public static function check(string $action, string $ip, int $limit = 5, int $windowSeconds = 900): bool
+    public static function check(string $action, string $identifier, int $limit = 5, int $windowSeconds = 900): bool
     {
-        $bucket = $action . ':' . $ip;
+        // Hash the identifier: keeps the bucket ≤191 chars for long emails and
+        // avoids storing raw emails/IPs in the table.
+        $bucket = $action . ':' . sha1($identifier);
         $pdo = Db::pdo();
 
         // $windowSeconds is an internal int constant — safe to inline.


### PR DESCRIPTION
## Summary
Rate-limit the login and register endpoints (the quick-win first slice of #79). Both were un-throttled on the live site.

- **register**: per-IP 10/15min (bulk-signup spam).
- **login**: per-IP 20 AND per-email 10, checked *before* the bcrypt verify (avoids CPU-DoS); per-email catches distributed targeting of a single account. 429 fires regardless of whether the account exists — non-enumeration preserved.
- `RateLimit` now hashes the identifier into `rate_limits.bucket` (fits long emails in the 191-char column, and stops storing raw emails/IPs).

Verified locally: register `400×10 → 429`; login same-email `401×10 → 429`; a different email keeps working under the per-IP cap. Two-file change (`RateLimit.php`, `AuthController.php`).

CAPTCHA (Cloudflare Turnstile) + edge protection (WAF/Bot Fight) remain tracked in #79.

## Changes
- Rate-limit login + register (part 1 of #79) (#80)

Closes #80