### PR TITLE
Close #82 - Doc sync: PHP backend rewrite, deploy pipeline, email + hosting correction

### DIFF
--- a/.changes/unreleased/82-doc-sync-php-backend-rewrite-deploy.md
+++ b/.changes/unreleased/82-doc-sync-php-backend-rewrite-deploy.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Changed -->
+- Doc sync: PHP backend rewrite, deploy pipeline, email + hosting correction ([#82](https://github.com/neturely/addiapp/issues/82))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,11 @@
 # AddiApp — Project Context
 
 > Authoritative project reference — supersedes stale chat history. Originally a
-> rebuild-planning draft (2026-07-11); synced 2026-07-12 to fold in the merged
-> work #25–#70 (see "What's built" below). Most core decisions are now settled;
-> remaining open items live in the Open decisions log. Where this file and the
-> code disagree, the code (on `develop`) wins — update this file to match.
+> rebuild-planning draft (2026-07-11); synced 2026-07-12 for the merged work
+> #25–#70, and re-synced 2026-07-13 for the **PHP backend rewrite (#77)**, the
+> **deploy pipeline (#39)**, and **live production email (#65)**. Most core
+> decisions are settled; open items live in the Open decisions log. Where this
+> file and the code disagree, the code (on `develop`) wins — update this file.
 
 ## What this project is
 
@@ -19,50 +20,54 @@ codebase is fully discarded — nothing carries forward except the general task
 concept (title/completed/timestamp) and font assets. No data-loss concern;
 the old app was never in real use.
 
-## My background
+**Status: Release 1 is LIVE at https://addiapp.com** (React SPA + PHP API + MySQL).
 
-*(Carried over from the wptips.com project on the assumption this is the same
-person/org — confirm or correct.)*
+## My background
 
 - Full-stack developer, 17+ years in IT (Java, Spring Boot, Node.js, React, PHP, Docker)
 - Based in Linköping, Sweden
 - AddiApp is a project under the Neturely umbrella (web hosting and development company)
 - Domain `addiapp.com` registered/proxied via Cloudflare
-- Hosting: KnownHost **shared hosting** (cPanel/CloudLinux/LiteSpeed) — note this
-  differs from wptips.com's KnownHost *Reseller* plan; confirm whether AddiApp
-  sits on the same account or a separate shared plan
-- Dev environment: presumably Mac/WSL2 Ubuntu, VSCode, Claude Code — **TBD, confirm**
+- Hosting: KnownHost **Basic Plus Reseller** — the SAME cPanel/CloudLinux/LiteSpeed
+  account as wptips.com (sister Neturely project), NOT a separate shared plan.
+  This plan does **not** offer Node.js app hosting (no CloudLinux Node.js
+  Selector), which is why the backend is PHP (see Decisions).
+- Dev environment: macOS + colima (Docker) + VSCode + Claude Code.
 
 ## Decisions already made — do not re-litigate
 
-- Platform: React (Vite) SPA + Node.js/Express API — not Next.js. SSR/App
-  Router doesn't fit KnownHost shared hosting + FTP deploy well.
-- Database: MySQL/MariaDB — not Postgres, not Supabase. Not available on
-  shared cPanel plans.
-- DB access: **Drizzle ORM** (+ `mysql2` driver) — decided. Schema in
-  `server/src/db/schema.ts`; generated SQL migrations in `server/drizzle/`.
+- Frontend: React (Vite) SPA — not Next.js. Static build served from the docroot.
+- Backend: **plain PHP 8.2 + PDO** (`api/`) — no framework, no Composer runtime
+  deps. NOT Node/Express (the KnownHost plan can't run Node) and not Next.js. The
+  original Node/Express/Drizzle `server/` was fully rewritten in PHP (#77); the
+  HTTP contract was preserved, so the client was untouched.
+- Database: MySQL/MariaDB — not Postgres, not Supabase.
+- DB access: **plain PDO**, parameterized queries. Schema is hand-written SQL in
+  `api/migrations/`, applied by `api/migrate.php` (tracked in a `_migrations`
+  table). No ORM (the Drizzle era ended with the PHP rewrite).
 - Auth: custom, self-rolled — **DB-backed server-side sessions** (opaque random
   token in an httpOnly `sid` cookie, 7-day TTL; the `sessions` row is the source
-  of truth, so logout/expiry revoke access immediately) + **bcryptjs** password
-  hashing (pure-JS, no native addon to compile on shared hosting). Sessions,
-  **not JWT**. Not Supabase Auth, not Auth.js/NextAuth.
+  of truth, so logout/expiry revoke access immediately) + **bcrypt** via PHP's
+  `password_hash`/`password_verify`. Sessions, **not JWT**. Not Supabase Auth.
 - Styling: Tailwind CSS v4 (utility classes, no config file; coral brand accents
   as arbitrary values like `bg-[#D85A30]`).
-- Transactional email: **Resend** (TypeScript SDK, `RESEND_API_KEY`) for the
-  verification + password-reset emails. Deliberately NOT Brevo: wptips.com uses
-  Brevo for its marketing/contacts/list/automation layer, which AddiApp doesn't
-  need — AddiApp is pure transactional, which is exactly Resend's niche. Two
-  intentional per-project choices for different needs, not an inconsistency to
-  reconcile. (Email verification #61 and password reset #62 are built and merged;
-  production still needs Resend domain verification for addiapp.com — #65.)
-- Hosting: KnownHost shared hosting — cPanel, CloudLinux, LiteSpeed, Node.js
-  Selector (Passenger) for the Express backend; static build served directly
-  for the frontend.
+- Transactional email: **Resend** (direct curl from PHP; `RESEND_API_KEY`) for
+  verification + password-reset. Deliberately NOT Brevo: wptips.com uses Brevo for
+  its marketing/contacts/automation layer, which AddiApp doesn't need — AddiApp is
+  pure transactional, exactly Resend's niche. Two intentional per-project choices,
+  not an inconsistency. Production email is **live** — `addiapp.com` verified in
+  Resend, sending from `no-reply@addiapp.com` (#61/#62/#65).
+- Hosting: KnownHost Basic Plus Reseller — cPanel/CloudLinux/LiteSpeed. LiteSpeed
+  serves the PHP backend directly (no process/Passenger to restart). **SSH is
+  available.**
 - Domain: `addiapp.com`, live, proxied through Cloudflare.
 - GitHub: org `neturely`, repo `addiapp`.
-- Deploy: GitHub Actions, FTP-based (existing `FTP-Deploy-Action` workflow is
-  stale/broken — targets an unrelated static-site branch, no build step —
-  will be replaced, not patched).
+- Deploy: **done (#39)** — GitHub Actions on push to `main` builds the SPA and
+  rsyncs it (+ the PHP `api/`) over SSH, then runs `php migrate.php`. No restart.
+  See docs/DEPLOY.md.
+- Secrets: production config in `~/api/config.php` (a PHP array **outside** the
+  web root, `chmod 600`, git-ignored, rsync-excluded) — NOT a `.env` (a PHP file
+  isn't served as plaintext even if exposed; `.env` is).
 - Old codebase/live site: fully disposable, no migration effort required.
 - Design mood: bold, colorful, mascot-driven (Duolingo-style personality, not
   literal look) layered on Todoist/Linear-level clean UI chrome. Trello's
@@ -70,235 +75,210 @@ person/org — confirm or correct.)*
   single-task-at-a-time, not a board.
 - Points visibility: shown up front (approximate) before task commitment —
   not hidden until completion. Deliberate: visibility is motivating.
-- Release strategy: build a minimal Release 1, defer competitive/social
+- Release strategy: minimal Release 1 (now live), defer competitive/social
   features (leaderboards, teams, projects, sharing) to later phases.
 
 ## Points / gamification system (finalized, #28)
 
-All numbers are FINAL and live in ONE file — `server/src/points/config.ts`.
-Tuning them never touches the pure math (`points/calculate.ts`) or the award
-orchestration (`points/award.ts`). See PROJECT_SPEC §7 for the full formulas.
+All numbers are FINAL and live in ONE file — `api/src/Points/PointsConfig.php`.
+Tuning them never touches the pure math (`Points/Calculate.php`) or the award
+orchestration (`Points/Award.php`). See PROJECT_SPEC §7 for the full formulas.
 
 - Base points: Low = 2, Medium = 5, High = 10.
-- Estimated time: entered manually at creation (minutes); not derived from
-  complexity.
+- Estimated time: entered manually at creation (minutes); not derived from complexity.
 - Speed bonus (saturation-based, anti-gaming): scales with time saved, reaching
   the ceiling of **+100% of base** (`SPEED_BONUS_MAX_RATIO = 1.0`) at
-  **≤50% of the estimate** (`SPEED_BONUS_SATURATION = 0.5`); 0 if on/over
-  estimate. No extra beyond saturation.
-- Daily multiplier: `min(1 + (n−1)·0.15, 2.0)` for the n-th completion of the
-  day (`GROWTH = 0.15`, `CAP = 2.0`) → cap reached at the **8th** task/day;
-  resets at midnight in `APP_TIMEZONE` (default **Europe/Stockholm**). Shown live
-  as the next task's multiplier. Total = `round((base + speedBonus) × multiplier)`.
-- Idempotency: points are awarded **once per task, ever** (first completion) —
-  reopening + re-completing does NOT re-award (the `points_log` ledger is checked
-  by `task_id`).
+  **≤50% of the estimate** (`SPEED_BONUS_SATURATION = 0.5`); 0 if on/over estimate.
+- Daily multiplier: `min(1 + (n−1)·0.15, 2.0)` for the n-th completion of the day
+  (`GROWTH = 0.15`, `CAP = 2.0`) → cap at the **8th** task/day; resets at midnight
+  in `APP_TIMEZONE` (default **Europe/Stockholm**). Total = `round((base + speed) × mult)`.
+- Idempotency: points awarded **once per task, ever** — enforced by a
+  `UNIQUE(task_id)` on `points_log` plus a duplicate-key catch, so even a
+  concurrent double-complete awards once (#74).
 - Points are shown up front (approximate base, before commitment) — decided.
 
 ## Task-selection algorithm (Play mode, #31)
 
-Behind a swappable interface in `server/src/tasks/selection.ts`
-(`SelectionStrategy = (candidates, rng?) => Task | null`). The route
+Behind a swappable seam in `api/src/Tasks/Selection.php`. The route
 (`GET /api/tasks/next`) filters candidates (win-type → complexity: small =
 {low, medium}, big = {medium, high}; time-available; backlog only; optional
 `exclude` for re-roll); the strategy only picks one — no selection logic in the
-route handler.
+controller.
 
 - Default: **`weightedByAge`** — weighted random favouring older tasks
-  (rank-based weights; oldest most likely, still random) for the "keep momentum"
-  feel. Alternates `oldestFirst` / `uniformRandom` ship too.
+  (rank-based weights; oldest most likely, still random). Alternates
+  `oldestFirst` / `uniformRandom` ship too.
 - A future **per-user selection preference** is designed for (swap
-  `strategies[user.preference]`) but **not built** — no settings page exists yet.
+  `Selection::strategies()[$name]`) but **not built** — no settings page yet.
 
-## What's built (maps to PROJECT_SPEC §5/§6)
+## What's built (maps to PROJECT_SPEC §5/§6) — LIVE at addiapp.com
 
-Merged to `develop` (#25–#38, #61, #62, #69). Quick orientation for a fresh session:
+Backend endpoints (PHP, `api/src/Controllers/`); the client contract is identical
+to the old Node API.
 
-- **Auth (#26, #61, #62)**: register / login / logout / `me`, DB-backed sessions,
-  bcryptjs. **Email verification** — register creates an unverified account and
-  emails a link (`/api/auth/verify`, `/resend-verification`); login is blocked
-  until verified. **Password reset** — `/api/auth/forgot-password` +
-  `/reset-password` (single-use token, bcrypt, revokes all sessions). Client
-  pages: `/verify`, `/forgot-password`, `/reset`. Email transport +
-  single-use tokens in `server/src/email/` + `email_tokens`.
-- **Task CRUD (#27)**: user-scoped `GET/POST/PATCH/DELETE /api/tasks`, plus
-  `GET /api/tasks/next` (selection).
-- **Points (#28)**: `GET /api/points` (lean, for the card) and
-  `GET /api/points/stats` (lifetime + streak, for the stats page).
+- **Auth (#26, #61, #62, #67, #80)**: `/api/auth/{register,login,logout,me,verify,
+  resend-verification,forgot-password,reset-password}`. DB-backed sessions, bcrypt.
+  Email verification gates login; password reset revokes all sessions. register
+  survives email-send failures (best-effort, #67). login/register + the email
+  endpoints are rate-limited (#80). Client pages: `/verify`, `/forgot-password`, `/reset`.
+- **Task CRUD (#27)**: user-scoped `GET/POST/PATCH/DELETE /api/tasks` + `GET /api/tasks/next`.
+- **Points (#28)**: `GET /api/points` (card) and `GET /api/points/stats` (lifetime + streak).
 - **Play mode (#29–#34, #69)**: Home `/`, Choice `/play`, Task `/play/task`,
   In-progress `/play/progress/:id`, Completion, Empty state, Resume-from-home.
-- **Dashboard (#36)**: `/dashboard` — table + inline edit (title/complexity/est/
-  status), full edit page `/tasks/:id/edit` (shared `TaskForm` with Add), status
-  filter tabs, per-row Start/Resume/Edit/Delete, undo-toast delete.
-- **Add task (#35)**: `/tasks/new`. **Points card (#37)** on the dashboard.
-  **Stats page (#38)**: `/stats`.
+- **Dashboard (#36)**: `/dashboard` — table + inline edit, full edit page
+  `/tasks/:id/edit` (shared `TaskForm`), status filter tabs, per-row
+  Start/Resume/Edit/Delete, undo-toast delete.
+- **Add task (#35)**: `/tasks/new`. **Points card (#37)**. **Stats page (#38)**: `/stats`.
+- **Deploy (#39)** + **production email (#65)** done.
 
-NOT yet on `develop`: deploy pipeline (#39), marketing homepage (#40, unscoped),
-user guide (#41, unscoped).
+NOT yet built: marketing homepage (#40, unscoped), user guide (#41, unscoped).
+Auth hardening beyond rate-limiting (CAPTCHA/edge) is #79.
 
 ## Repo structure
 
-Monorepo (npm workspaces) — **decided**. Client and server in one repo.
+Monorepo (npm workspaces for the client only; the PHP `api/` isn't an npm package).
 
 ```
 addiapp/
 ├── docker-compose.yml            # local MySQL 8.0 for development
 ├── scripts/db.sh                 # db:up/down/reset helper (macOS vs Linux compose)
-├── .github/workflows/            # (deploy pipeline rewrite is issue #39)
+├── .github/workflows/deploy.yml  # build SPA + rsync + migrate over SSH (#39)
+├── docs/DEPLOY.md                # pipeline, secrets, one-time server setup
 ├── client/                       # React 19 + Vite SPA (TypeScript)
+│   └── src/                      #   pages/, components/, auth/, lib/, router.tsx
+│       └── public/.htaccess      #   SPA routing (ships in the build)
+├── api/                          # PHP 8.2 + PDO backend (replaces the old server/)
+│   ├── public/index.php          #   front controller (router + bootstrap)
+│   ├── public/.htaccess          #   rewrite → index.php
+│   ├── router.php                #   dev router for `php -S`
+│   ├── migrate.php               #   applies migrations/*.sql (tracked in _migrations)
+│   ├── migrations/*.sql          #   schema
+│   ├── config.example.php        #   copy to config.php (prod, outside web root)
 │   └── src/
-│       ├── pages/                # Home, Login, Register, Verify, ForgotPassword,
-│       │                         #   ResetPassword, Choice, TaskPresented,
-│       │                         #   InProgress, AddTask, EditTask, Dashboard,
-│       │                         #   Stats, NotFound
-│       ├── components/           # Mascot, EmptyState, Completion, PointsCard,
-│       │                         #   TaskForm, ProtectedRoute
-│       ├── auth/                 # AuthProvider, authContext, useAuth
-│       ├── lib/                  # api.ts + apiError.ts (apiRequest wrapper),
-│       │                         #   tasks.ts, points.ts (raw-fetch clients)
-│       └── router.tsx
-├── server/                       # Node.js + Express API (TypeScript)
-│   ├── drizzle/                  # generated SQL migrations (0000–0002)
-│   └── src/
-│       ├── db/                   # Drizzle schema, connection, migrator
-│       ├── auth/                 # passwords (bcryptjs), sessions, emailTokens
-│       ├── email/                # Resend + console transport, templates (#61/#62)
-│       ├── points/              # config.ts (tunables), calculate.ts, award.ts
-│       ├── tasks/                # selection.ts (swappable SelectionStrategy)
-│       ├── routes/               # health, auth, tasks, points
-│       ├── middleware/           # requireAuth
-│       ├── config.ts             # env-sourced runtime config (appUrl, Resend)
-│       └── app.ts / index.ts
+│       ├── Config, Db            #   env/config + PDO
+│       ├── Http/                 #   Request, Response, Router
+│       ├── Auth/                 #   Passwords (bcrypt), Sessions, EmailTokens
+│       ├── Email/                #   Resend (curl) + console transports, templates
+│       ├── Points/               #   PointsConfig, Calculate, Award
+│       ├── Tasks/Selection.php   #   swappable weighted-random selection
+│       ├── RateLimit.php         #   DB fixed-window limiter
+│       └── Controllers/          #   Auth, Tasks, Points, Health
 ├── public/fonts/                 # Nunito web fonts (kept from original)
-├── CLAUDE.md
-├── PROJECT_SPEC.md
-└── README.md
+├── CLAUDE.md · PROJECT_SPEC.md · README.md
 ```
 
 ## Local dev environment
 
-- Docker Compose (Mac or WSL2 Ubuntu) — a **MySQL 8.0 container only**; the app
-  (client + server) runs on the host, not in containers. No MySQL is installed
-  on the host itself.
-- DB access layer: **Drizzle ORM** (+ `mysql2` driver). Schema lives in
-  `server/src/db/schema.ts`.
+- Docker Compose (macOS + colima) — a **MySQL 8.0 container only**; the app runs
+  on the host. Requires PHP 8.2+ on the host.
 - First-time setup:
-  1. `cp .env.example .env` and `cp server/.env.example server/.env`
+  1. `cp .env.example .env` (docker MySQL creds)
   2. `npm install`
-  3. `npm run db:up` — starts MySQL 8.0 (exposed on `localhost:3306`, data in the
-     `db_data` volume)
-  4. `npm run db:migrate` — applies Drizzle migrations from `server/drizzle/`
-  5. `npm run dev` — client on http://localhost:5173, API on http://localhost:3001
-- Changing the schema: edit `server/src/db/schema.ts`, then `npm run db:generate`
-  to emit a new SQL migration, then `npm run db:migrate` to apply it.
-- `DATABASE_URL` in `server/.env` must match the `MYSQL_*` credentials in the
-  root `.env` (both default to user `addiapp` / password `addiapp` / db `addiapp`).
-- Reset the DB (drop the volume + recreate) with `npm run db:reset`; stop it with
-  `npm run db:down` (data persists in the `db_data` volume). The `db:up`/`db:down`
-  scripts (`scripts/db.sh`) auto-pick `docker-compose` on macOS and `docker
-  compose` on Linux/WSL, matching wptips.
-- **macOS + colima gotcha:** if `docker` reports "command not found" even though
-  colima is installed, the Homebrew `docker` CLI just isn't linked. Fix once:
-  `ln -sf "$(brew --prefix docker)/bin/docker" /opt/homebrew/bin/docker` then
-  `colima start`.
+  3. `npm run db:up` — MySQL 8.0 on `localhost:3306` (data in the `db_data` volume)
+  4. `npm run db:migrate` — runs `php api/migrate.php`
+  5. `npm run dev` — client on http://localhost:5173, PHP API on
+     http://127.0.0.1:3001 (Vite proxies `/api`)
+- No local `api/config.php` is needed — the built-in defaults point at the docker
+  MySQL. With no `RESEND_API_KEY`, emails use the console transport (links logged
+  to the API output).
+- Changing the schema: add a numbered `.sql` to `api/migrations/`, then
+  `npm run db:migrate`. Reset with `npm run db:reset`.
+- **macOS + colima gotcha:** if `docker` reports "command not found" though colima
+  is installed, the Homebrew `docker` CLI isn't linked. Fix once:
+  `ln -sf "$(brew --prefix docker)/bin/docker" /opt/homebrew/bin/docker` then `colima start`.
 
 ## Screens (built)
 
-All Play-mode and dashboard screens are implemented and merged to `develop`
-(#29–#38, #69) — see "What's built" above and PROJECT_SPEC §5/§6. The only
-screens still not designed/built are the marketing/landing homepage (#40) and
-the user guide/help content (#41) — both unscoped.
+All Play-mode and dashboard screens are implemented and live (#29–#38, #69). The
+only screens not built are the marketing/landing homepage (#40) and user
+guide/help content (#41) — both unscoped.
 
-Mascot: placeholder simple flat character only (used consistently across all
-screens). Real mascot art + expression variations is a deliberate later design
-pass, likely in Claude Design once the UX flow is locked.
+Mascot: placeholder simple flat character only. Real mascot art + expression
+variations is a deliberate later design pass, likely in Claude Design.
 
-Color palette used in mockups: warm coral primary (`#D85A30`), supporting
-teal/amber/purple for badges/tags — not a literal Duolingo green, not yet
-locked as final brand palette.
+Color palette: warm coral primary (`#D85A30`), supporting teal/amber/purple for
+badges/tags — not a literal Duolingo green, not yet locked as final brand palette.
 
 ## Coding standards
 
-- TypeScript on both client and server — confirmed.
-- React functional components + hooks, no class components.
-- Express: standard REST conventions; route handlers stay thin, business logic
-  lives in modules (`points/`, `tasks/selection.ts`).
-- DB access via **Drizzle ORM** (parameterized) — no raw string concatenation.
-- Client API calls: a shared `apiRequest` wrapper (`client/src/lib/api.ts`, from
-  #61) that sends cookies and throws `ApiError` — the auth pages use it. The
-  older Play-mode clients (`lib/tasks.ts`, `lib/points.ts`) still use plain
-  `fetch` with `credentials: 'include'`; unifying them onto `apiRequest` is a
-  future cleanup, not required.
-- **Zod** validates request bodies/queries server-side; the client mirrors the
-  same rules for fast feedback, but the server is authoritative.
-- Environment variables via `.env` (never committed).
+- **Client**: TypeScript, React functional components + hooks (no classes).
+  API calls via the `apiRequest` wrapper (`client/src/lib/api.ts`) or plain
+  `fetch` with `credentials: 'include'` in the Play-mode clients.
+- **Backend (PHP 8.2)**: plain PHP + PDO, no framework, no Composer runtime deps.
+  Thin controllers; logic in modules (`Points/`, `Tasks/Selection.php`, `Auth/`).
+  PDO **parameterized** queries only — never string-concatenate SQL. PSR-4-ish
+  autoloader (`App\` → `api/src/`). Input validated server-side; the server is
+  authoritative (the client mirrors rules for UX).
+- Secrets: production `api/config.php` (PHP array, outside the web root, `600`,
+  git-ignored). Never a committed/web-served `.env`.
 
-## Deployment — TBD, key open question
+## Deployment (done — #39)
 
-- GitHub Actions → FTP sync is confirmed for the static frontend build.
-- The Express backend cannot be deployed via FTP alone (FTP doesn't restart a
-  Node process). **Open question: is SSH available on this KnownHost shared
-  plan?** This determines whether backend deploy can be scripted (SSH +
-  cPanel API / Passenger restart) or requires manual intervention in cPanel
-  after each deploy.
-- No `.htaccess`, reverse proxy config, or SPA rewrite rules written yet —
-  needed once the frontend is a client-routed SPA under Apache/LiteSpeed.
+- GitHub Actions (`.github/workflows/deploy.yml`) on push to `main`: build the
+  SPA, `rsync --delete` `client/dist` → `public_html` and `api/` → `~/api`
+  (keeping `config.php`, `.well-known`, `cgi-bin`, the `api` symlink), then
+  `ssh … php ~/api/migrate.php`. **No process to restart** (PHP).
+- Routing: `public_html/api` is a **symlink** to `~/api/public`, so
+  `addiapp.com/api/*` hits the PHP front controller; the SPA `.htaccess` handles
+  client-side routing and skips `/api`.
+- Secrets on the server: `~/api/config.php` (DB creds, `RESEND_API_KEY`, `appUrl`,
+  `emailFrom`, `isProd`). GitHub secrets: `DEPLOY_SSH_{HOST,USER,PORT,KEY}`.
+- Full details + one-time server setup: **docs/DEPLOY.md**.
 
 ## How to help me
 
 - Assume strong technical knowledge — skip basic explanations unless asked
 - Ask, don't assume — if intent/architecture/requirements are unclear, ask
-  before writing code (this project is early-stage; a lot is still TBD, so
-  expect more clarifying questions than a mature project)
-- Lead with the most practical solution first; call out hosting/deployment
-  constraints specific to KnownHost shared hosting when relevant
-- Actively suggest better/longer-lasting solutions when you see one, but
-  match complexity to the problem — this is a personal project, not
-  enterprise software; don't over-engineer
+  before writing code
+- Lead with the most practical solution first; call out KnownHost cPanel/PHP/
+  LiteSpeed constraints when relevant
+- Actively suggest better/longer-lasting solutions, but match complexity to the
+  problem — this is a personal project, don't over-engineer
 - Keep responses focused
 
 ## Never do these things
 
-- Never suggest Next.js, SSR, or any framework/pattern that assumes a
-  Vercel-style host — this is shared cPanel hosting via FTP
-- Never suggest Postgres or Supabase — MySQL/MariaDB only, self-hosted auth
-- Never suggest Auth.js/NextAuth — custom auth only
-- Never suggest hiding points until task completion — decided to show them
-  up front
-- Never reintroduce anything from the old codebase without it being an
-  explicit, deliberate decision — default assumption is "discarded"
-- Never assume SSH is available on the shared plan until confirmed — deploy
-  suggestions should account for FTP-only as the safe default until this is
-  resolved
-- Never "fix" AddiApp to use Brevo for consistency with wptips.com — AddiApp
-  uses Resend for transactional email by deliberate choice; they are
-  intentionally different providers for different needs.
-- Never switch auth to JWT or a client-stored token — it's DB-backed sessions
-  (opaque httpOnly `sid` cookie) by decision, so logout/expiry revoke immediately.
-- Never inline task-selection logic into the route — it lives behind the
-  `SelectionStrategy` interface (`server/src/tasks/selection.ts`) so a per-user
-  preference stays a one-line swap.
-- Never hardcode points numbers outside `server/src/points/config.ts` — that's
-  the single source; the client reads base points from `GET /api/points`.
+- Never suggest Node.js/Express/Next.js or any server that needs a persistent
+  Node process — this plan runs PHP under LiteSpeed only.
+- Never suggest Postgres or Supabase — MySQL/MariaDB only, self-hosted auth.
+- Never suggest Auth.js/NextAuth — custom auth only.
+- Never switch auth to JWT or a client-stored token — DB-backed sessions (opaque
+  httpOnly `sid` cookie) by decision, so logout/expiry revoke immediately.
+- Never suggest hiding points until task completion — decided to show them up front.
+- Never "fix" AddiApp to use Brevo for consistency with wptips.com — AddiApp uses
+  Resend by deliberate choice; different providers for different needs.
+- **Never reference wptips.com's private editorial identity (the "Elise Porter" /
+  `elise@` persona) anywhere in AddiApp** — separate projects, no shared identity.
+  (It leaked once into a prod email `From`; scrubbed. Don't copy it from wptips
+  context.)
+- Never put production secrets in a committed or web-served `.env` — use
+  `api/config.php` (PHP array, outside the web root, `600`).
+- Never inline task-selection logic into the controller — it lives behind
+  `api/src/Tasks/Selection.php` so a per-user preference stays a one-line swap.
+- Never hardcode points numbers outside `api/src/Points/PointsConfig.php` — the
+  single source; the client reads base points from `GET /api/points`.
+- Never reintroduce the old Next.js/Supabase codebase without an explicit decision.
 
 ## Open decisions log
 
-Resolved items removed in the 2026-07-12 sync. Genuinely still open:
+Genuinely still open:
 
-- [ ] Node.js version to target on KnownHost (Passenger / Node.js Selector)
-- [ ] SSH availability on KnownHost shared plan (drives backend deploy — #39)
 - [ ] Marketing / landing homepage scope (#40)
 - [ ] User guide / help content scope (#41)
-- [ ] Production email readiness — Resend domain verification for addiapp.com (#65)
-- [ ] Signup rate-limiting / auth abuse protection
+- [ ] Auth hardening beyond rate-limiting — CAPTCHA (Cloudflare Turnstile) + edge
+  protection (#79)
 - [ ] Privacy policy / Terms of Service pages
-- [ ] Home secondary-link set (Add task / Dashboard / Stats) — right long-term
-  set vs. a single Dashboard entry (noted at #29's merge)
+- [ ] Home secondary-link set (Add task / Dashboard / Stats) vs. a single entry (#29)
 - [ ] Final color palette / brand direction (placeholder warm coral in use)
 - [ ] Real mascot art (placeholder flat character in use)
-- [x] Monorepo vs split repos — **monorepo** (npm workspaces)
-- [x] Query builder / ORM — **Drizzle ORM** (+ mysql2)
-- [x] Auth model — **DB-backed sessions + bcryptjs** (not JWT)
-- [x] Speed-bonus formula, daily-multiplier cap/growth — **finalized** (§7)
-- [x] Task-selection algorithm — **weighted-random, swappable strategy**
-- [x] In-progress / completion / add-task / dashboard designs — **built**
+
+Resolved (kept for reference):
+
+- [x] Backend language — **PHP 8.2 + PDO** (Node isn't available on the plan; #77)
+- [x] Hosting — **same KnownHost Basic Plus Reseller box as wptips** (not a separate plan)
+- [x] SSH availability — **yes**; deploy is Actions + rsync + SSH migrate (#39)
+- [x] Production email readiness — **domain verified, live** (#65)
+- [x] Auth model — DB-backed sessions + bcrypt (not JWT)
+- [x] Points formulas + task-selection algorithm — finalized
+- [x] Play/dashboard designs — built
+- [x] Monorepo (client workspace) — kept

--- a/PROJECT_SPEC.md
+++ b/PROJECT_SPEC.md
@@ -18,45 +18,43 @@ title/completed/timestamp) and font assets.
 
 ## 2. Tech stack (decided)
 
-Chosen specifically to fit **KnownHost shared hosting** (cPanel, CloudLinux,
-LiteSpeed, Node.js Selector via Passenger, MySQL/MariaDB — no root/SSH
-confirmed yet, FTP-based deploy via GitHub Actions).
+Fit to the **KnownHost Basic Plus Reseller** account (cPanel/CloudLinux/LiteSpeed,
+MySQL, SSH available) — the SAME box as wptips.com. The plan does **not** run
+Node.js apps (no CloudLinux Node.js Selector), which drove the PHP backend.
 
-- **Frontend**: React 19 + Vite, static build (SPA, client-side routing via
-  React Router v7). No Next.js — SSR/App Router doesn't fit shared hosting +
-  FTP deploy well.
-- **Backend**: Node.js + Express (TypeScript), run via cPanel's "Setup Node.js
-  App" (Passenger).
-- **Database**: MySQL/MariaDB (not Postgres — not available on shared cPanel
-  plans). Local dev uses a MySQL 8.0 Docker container.
-- **DB access layer**: **Drizzle ORM** (+ `mysql2` driver) — *resolved*. Schema
-  in `server/src/db/schema.ts`; generated SQL migrations in `server/drizzle/`.
-- **Auth (#26, #61, #62)**: custom, self-rolled — **DB-backed server-side
-  sessions** (opaque random token in an httpOnly `sid` cookie, 7-day TTL, the
-  `sessions` row is the source of truth so logout/expiry revoke immediately) +
-  **bcryptjs** password hashing (pure-JS, no native build). Registration creates
-  an **unverified** account and emails a verification link; **login is blocked
-  until verified** (#61). **Password reset** (#62) emails a single-use token;
-  confirming it sets a new bcrypt password and **revokes all existing sessions**.
-  Endpoints: `/api/auth/{register, login, logout, me, verify,
-  resend-verification, forgot-password, reset-password}`. Sessions, not JWT; not
-  Supabase Auth, not Auth.js/NextAuth.
-- **Styling**: Tailwind CSS v4 (via `@tailwindcss/vite`, no config file —
-  utility classes; brand accents used as arbitrary values, e.g. `bg-[#D85A30]`).
-- **Transactional email**: **Resend** (TypeScript SDK, `RESEND_API_KEY`; a
-  console transport is used in dev when the key is unset, so the full flow runs
-  locally). Deliberately NOT Brevo (see CLAUDE.md). Powers **email verification
-  (#61)** and **password reset (#62)** — both built and merged. A
-  provider-agnostic `EmailService` lives in `server/src/email/`; single-use
-  tokens live in `email_tokens` (`verify` 24h / `reset` 1h TTL). Production still
-  needs Resend **domain verification** for addiapp.com (#65) before live sends to
-  arbitrary recipients.
-- **Deploy**: GitHub Actions. Static frontend build synced via FTP; Express
-  backend deploy mechanism still open (FTP alone doesn't restart a Node
-  process — need to confirm SSH availability on the shared plan).
+- **Frontend**: React 19 + Vite, static build (SPA, React Router v7). No Next.js.
+  Served from the docroot; `.htaccess` (shipped from `client/public/`) does
+  client-side routing.
+- **Backend**: **plain PHP 8.2 + PDO** (`api/`) — no framework, no Composer
+  runtime deps. Rewritten from Node/Express/Drizzle (#77) after Node turned out to
+  be unavailable on the plan; the HTTP contract was preserved so the client was
+  untouched. A thin front controller + minimal router; controllers in
+  `api/src/Controllers/`. Verified on the account: PHP 8.2 (7.4–8.5 available),
+  extensions pdo_mysql/curl/openssl/mbstring/etc.
+- **Database**: MySQL/MariaDB. Local dev uses a MySQL 8.0 Docker container.
+- **DB access**: **plain PDO** (parameterized). Schema is hand-written SQL in
+  `api/migrations/`, applied by `api/migrate.php` (tracked in `_migrations`). No
+  ORM.
+- **Auth (#26, #61, #62, #67, #80)**: custom — **DB-backed sessions** (opaque
+  httpOnly `sid` cookie, 7-day TTL) + **bcrypt** (`password_hash`). Registration
+  creates an unverified account + emails a link; **login is blocked until
+  verified**; register survives email-send failures (best-effort, #67). **Password
+  reset** sets a new password + **revokes all sessions**. login/register + the
+  email endpoints are **rate-limited** (DB fixed-window, #80). Endpoints:
+  `/api/auth/{register, login, logout, me, verify, resend-verification,
+  forgot-password, reset-password}`. Sessions, not JWT; not Supabase/Auth.js.
+- **Styling**: Tailwind CSS v4 (utility classes; brand accents as arbitrary
+  values, e.g. `bg-[#D85A30]`).
+- **Transactional email**: **Resend** via direct curl from PHP (`RESEND_API_KEY`;
+  a console transport is used in dev when unset). Deliberately NOT Brevo (see
+  CLAUDE.md). Powers verification (#61) + password reset (#62); single-use tokens
+  in `email_tokens` (`verify` 24h / `reset` 1h). Production email is **live** —
+  `addiapp.com` verified in Resend, sending from `no-reply@addiapp.com` (#65).
+- **Deploy (#39, done)**: GitHub Actions on push to `main` builds the SPA, rsyncs
+  it + the PHP `api/` over SSH, then `php migrate.php`. No process restart. Live
+  at addiapp.com. Secrets in `~/api/config.php` (PHP array, outside the web root).
 
-Still open (see §10): Node.js version to target on KnownHost (Passenger),
-SSH availability on the shared plan (drives backend deploy/restart).
+Everything in §2 is resolved. Remaining open items are product/scope (§10).
 
 ## 3. Domain / infra (confirmed)
 
@@ -122,11 +120,8 @@ four-screen flow.
 
 ### Task-selection algorithm (resolved — was §10's oldest open item)
 
-Lives behind a swappable interface in `server/src/tasks/selection.ts`:
-
-```ts
-type SelectionStrategy = (candidates: Task[], rng?: () => number) => Task | null
-```
+Lives behind a swappable seam in `api/src/Tasks/Selection.php` (strategies take an
+already-filtered candidate list + an injectable rng and return one task or null):
 
 - The route (`GET /api/tasks/next`) does the **filtering** — win-type → complexity
   (`small` = {low, medium}, `big` = {medium, high}; medium is in both pools so the
@@ -185,11 +180,10 @@ the **current daily multiplier**, plus today's summary. Reads a richer
 
 ## 7. Points / gamification system — FINALIZED (#28)
 
-All numbers are final and live in **one file, `server/src/points/config.ts`** —
-tuning them after real usage never touches the calculation logic
-(`server/src/points/calculate.ts`, pure math) or the award orchestration
-(`server/src/points/award.ts`, DB writes). Base points are also surfaced to the
-UI via `GET /api/points` so the front end never hardcodes them.
+All numbers are final and live in **one file, `api/src/Points/PointsConfig.php`** —
+tuning them never touches the calculation logic (`Points/Calculate.php`, pure
+math) or the award orchestration (`Points/Award.php`, DB writes). Base points are
+also surfaced to the UI via `GET /api/points` so the front end never hardcodes them.
 
 - **Base points by complexity** (set at task creation): Low = 2, Medium = 5,
   High = 10.
@@ -235,8 +229,9 @@ change.
 **Decided**: a genuinely minimal first release. Reconciled against what's now
 actually built and merged to `develop`.
 
-### Release 1 — status
-- ✅ Custom auth (register/login/logout, bcryptjs + DB-backed sessions) — #26
+### Release 1 — status (LIVE at addiapp.com)
+- ✅ Custom auth (register/login/logout, bcrypt + DB-backed sessions) — #26,
+  hardened against email-send failures (#67), login/register rate-limited (#80)
 - ✅ Task CRUD, user-scoped (title, complexity, estimated time) — #27
 - ✅ Points system as defined in §7 (all numbers finalized) — #28
 - ✅ Play mode: Home → Choice → Task presented → Start → In-progress →
@@ -248,8 +243,11 @@ actually built and merged to `develop`.
 - ⬜ **Marketing / landing homepage** (#40) — the only remaining Release-1 item
   on the app itself; **not yet scoped**.
 - ⬜ **Basic user guide / help content** (#41) — **not yet scoped**.
-- ✅ Email verification (#61) + password reset (#62) — Resend transactional email.
-- ◻ Deploy pipeline (GitHub Actions build + FTP + Express restart) — #39, open.
+- ✅ Email verification (#61) + password reset (#62) — production email **LIVE** (#65).
+- ✅ **Backend rewritten to PHP 8.2 + PDO** (Node unavailable on the plan) — #77.
+- ✅ Deploy pipeline (GitHub Actions + rsync + `php migrate.php` over SSH) — #39.
+- ⬜ Marketing / landing homepage (#40) and user guide (#41) — the only remaining
+  Release-1 items, both **not yet scoped**.
 
 ### Explicitly deferred to later releases
 - Multi-user competitive features: leaderboards, scoreboard
@@ -288,30 +286,30 @@ into the rebuild as code:
 
 Rewritten in this sync — resolved items removed. Genuinely still open:
 
-- [ ] **Node.js version** to target on KnownHost (Passenger / Node.js Selector).
-- [ ] **SSH availability** on the KnownHost shared plan (drives backend
-  deploy/restart mechanism; assume FTP-only until confirmed). Deploy pipeline
-  rewrite is #39.
 - [ ] **#40 marketing / landing homepage** — scope/content not defined.
 - [ ] **#41 user guide / help content** — scope/content not defined.
-- [ ] **Production email readiness** — Resend domain verification for
-  `addiapp.com` (#65) before the email features (#61/#62) can be relied on in
-  production.
-- [ ] **General signup rate-limiting / abuse protection** on auth endpoints.
+- [ ] **Auth hardening beyond rate-limiting** — CAPTCHA (Cloudflare Turnstile) +
+  edge protection (WAF/Bot Fight). Login/register rate-limiting is done (#80); the
+  rest is #79.
 - [ ] **Privacy policy / Terms of Service** pages (needed before public launch).
-- [ ] **Home secondary-link tension** — the original mockup called for a
-  "Dashboard" secondary link; the built Home now carries Add task / Dashboard /
-  Stats. Whether that's the right long-term set (vs. a single Dashboard entry) is
-  an open UX call noted at #29's merge.
-- [ ] Final color palette / brand direction (mockups use placeholder warm coral).
+- [ ] **Home secondary-link set** — Add task / Dashboard / Stats vs. a single
+  Dashboard entry (open UX call, #29).
+- [ ] Final color palette / brand direction (placeholder warm coral in use).
 - [ ] Real mascot art (placeholder flat character in use).
 
-## 11. Change log — documentation sync (2026-07-12)
+Resolved since the last sync: backend language (**PHP**, #77), hosting (**same
+Basic Plus Reseller as wptips**), SSH availability (**yes**), deploy (**#39**),
+production email (**#65, live**).
 
-This spec was last substantively updated at #24 (scaffolding). This pass folds in
-the merged work #25–#70 (schema #25, auth #26, task CRUD #27, points #28, Play
-mode #29–#34, add-task #35, dashboard #36, points card #37, stats #38, resume
-#69) ahead of the `develop → main` promotion; a follow-up pass then folded in
-**email verification (#61)** and **password reset (#62)** once they merged. Where
-docs and code disagreed, code won. Still not on `develop`: the deploy pipeline
-(#39) and the unscoped #40/#41.
+## 11. Change log — documentation syncs
+
+- **2026-07-12** — folded in the merged work #25–#70 (schema, auth, task CRUD,
+  points, Play mode, add-task, dashboard, points card, stats, resume), then email
+  verification (#61) + password reset (#62), ahead of the first `develop → main`
+  promotion (Release 1, v1.0.0).
+- **2026-07-13** — the big pivot: the KnownHost plan can't run Node, so the
+  backend was **rewritten from Node/Express/Drizzle to plain PHP 8.2 + PDO**
+  (#77); the **deploy pipeline** (#39) and **production email** (#65) went live;
+  login/register **rate-limiting** (#80) landed. Corrected the hosting note (same
+  Basic Plus Reseller box as wptips.com). AddiApp is now **live at addiapp.com**.
+  Where docs and code disagreed, code won.


### PR DESCRIPTION
## Summary
Docs-only sync of CLAUDE.md + PROJECT_SPEC.md for the recent backend pivot (code is the source of truth).

- **Backend → PHP**: everything describing Node/Express/Drizzle now describes plain PHP 8.2 + PDO (`api/`) — tech stack (§2), repo tree, coding standards, points/selection file paths, local-dev commands, deployment section.
- **Hosting corrected**: same KnownHost **Basic Plus Reseller** box as wptips.com (not a separate shared plan); the plan's lack of Node hosting is why the backend is PHP.
- **Deploy (#39) done**: GitHub Actions + rsync + `php migrate.php` over SSH; **app live at addiapp.com**. Secrets in `~/api/config.php` (PHP array outside the web root — documented why that beats a `.env`).
- **Email (#65) live**: Resend, verified domain, `no-reply@addiapp.com`.
- **Rate-limiting (#80)** noted; open-decisions log rewritten (SSH/deploy/email/Node/ORM resolved; remaining: #40/#41 unscoped, #79 captcha/edge).
- Added a **never-do** guarding against leaking wptips's private editorial identity (`Elise Porter`/`elise@`) into AddiApp — it slipped into a prod email `From` once and was scrubbed.

No code touched.

## Changes
- docs: sync for the PHP backend rewrite, deploy, and live email (#82)

Closes #82