### PR TITLE
Close #85 - Harden CORS + null-safe task reloads (PR #84 review fixes)

### DIFF
--- a/.changes/unreleased/85-harden-cors-null-safe-task-reloads.md
+++ b/.changes/unreleased/85-harden-cors-null-safe-task-reloads.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Fixed -->
+- Harden CORS + null-safe task reloads (PR #84 review fixes) ([#85](https://github.com/neturely/addiapp/issues/85))

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "okffs": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "@neturely/okffs@latest"
+      ],
+      "env": {}
+    }
+  }
+}

--- a/api/public/index.php
+++ b/api/public/index.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require dirname(__DIR__) . '/src/autoload.php';
 
+use App\Config;
 use App\Controllers\AuthController;
 use App\Controllers\HealthController;
 use App\Controllers\PointsController;
@@ -25,10 +26,13 @@ set_exception_handler(static function (\Throwable $e): void {
 date_default_timezone_set('UTC');
 
 // CORS: in dev the Vite proxy makes /api same-origin; in prod the SPA is served
-// from the same host. Reflected origin + credentials keeps the session cookie
-// working if the API is ever hit cross-origin.
+// from the same host. Because responses carry the session cookie
+// (Access-Control-Allow-Credentials: true), the allowed origin must be an exact
+// allowlist — never a reflected arbitrary origin — so cross-site JS can't read
+// authenticated responses. The only trusted origin is the configured SPA base.
 $origin = $_SERVER['HTTP_ORIGIN'] ?? '';
-if ($origin !== '') {
+$allowedOrigins = array_filter([rtrim((string) Config::get('appUrl'), '/')]);
+if ($origin !== '' && in_array($origin, $allowedOrigins, true)) {
     header('Access-Control-Allow-Origin: ' . $origin);
     header('Vary: Origin');
     header('Access-Control-Allow-Credentials: true');

--- a/api/src/Controllers/TasksController.php
+++ b/api/src/Controllers/TasksController.php
@@ -103,7 +103,13 @@ final class TasksController
         $pdo = Db::pdo();
         $pdo->prepare('INSERT INTO tasks (user_id, title, complexity, estimated_minutes) VALUES (?, ?, ?, ?)')
             ->execute([$req->userId, $title, $complexity, $minutes]);
-        Response::json(['task' => self::mapTask(self::findOwned($pdo, (int) $pdo->lastInsertId(), (int) $req->userId))], 201);
+
+        $created = self::findOwned($pdo, (int) $pdo->lastInsertId(), (int) $req->userId);
+        if ($created === null) {
+            Response::error('Failed to load created task', 500);
+            return;
+        }
+        Response::json(['task' => self::mapTask($created)], 201);
     }
 
     /** GET /api/tasks/{id} */
@@ -213,9 +219,14 @@ final class TasksController
         $pdo->prepare('UPDATE tasks SET ' . implode(', ', $sets) . ' WHERE id = ? AND user_id = ?')->execute($args);
 
         $updated = self::findOwned($pdo, $id, (int) $req->userId);
+        if ($updated === null) {
+            // Concurrent delete between UPDATE and reload — the task is gone.
+            Response::error('Task not found', 404);
+            return;
+        }
 
         $pointsAwarded = null;
-        if ($completing && $updated !== null) {
+        if ($completing) {
             $pointsAwarded = Award::awardTaskCompletion(
                 (int) $updated['id'],
                 (int) $updated['user_id'],


### PR DESCRIPTION
## Summary
Addresses the 3 Copilot review findings on PR #84 (the v1.1.0 develop→main promotion), landing on develop so #84 picks them up.

1. CORS (api/public/index.php) — was reflecting any Origin with credentials enabled; now restricted to an exact allowlist of the configured appUrl. Smoke-tested with php -S: the allowed origin is echoed with ACA-Credentials; a foreign origin and an origin-less request get no CORS headers.
2. TasksController::create() — guards the post-insert findOwned() reload; returns a controlled 500 JSON error instead of a TypeError if the row can't be reloaded.
3. TasksController::update() — guards the post-update reload; returns 404 if a concurrent delete makes it null. Removes the now-redundant null check on the points-award branch.

Both files pass php -l.

## Changes
- chore: init branch for #85
- Harden CORS to an appUrl allowlist and null-guard task reloads

## Issue comments

```
### 🔧 Commit update

**Commit:** `dfb747a`
**Message:** Harden CORS to an appUrl allowlist and null-guard task reloads
**Time:** 2026-07-13T11:14:08.850Z

**Files changed:**
- `api/public/index.php`
- `api/src/Controllers/TasksController.php`

**Summary:** Harden CORS to an appUrl allowlist and null-guard task reloads

- api/public/index.php: restrict Access-Control-Allow-Origin to the configured appUrl (exact allowlist) instead of reflecting any Origin, since responses carry credentials. Verified via php -S: allowed origin echoed, evil/no origin gets no CORS headers.
- TasksController::create(): 500 with a controlled JSON error if the created row can't be reloaded (findOwned can return null).
- TasksController::update(): 404 if a concurrent delete makes the post-update reload null; drops the now-redundant null check on the points-award branch.

Addresses the 3 Copilot findings on PR #84.
```


Closes #85