### PR TITLE
Close #92 - Visual refresh v2 (A) — design tokens + Header/Footer shell + layout wiring

### DIFF
--- a/.changes/unreleased/92-visual-refresh-v2-a-design-tokens.md
+++ b/.changes/unreleased/92-visual-refresh-v2-a-design-tokens.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Changed -->
+- Visual refresh v2 (A) — design tokens + Header/Footer shell + layout wiring ([#92](https://github.com/neturely/addiapp/issues/92))

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc -b"
   },
   "dependencies": {
+    "lucide-react": "^1.24.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.1.1"

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -1,0 +1,26 @@
+import { Outlet } from 'react-router-dom'
+import { Header } from './Header'
+import { Footer } from './Footer'
+
+/**
+ * Persistent shell for every authed screen (visual refresh v2, #92): Header →
+ * page → Footer on the cream page background. Inserted once at the ProtectedRoute
+ * seam so all authed routes (incl. Play mode) gain it.
+ *
+ * The shell is a full-height flex column (header + flex-1 content + footer) and
+ * OWNS page height: the `.app-shell-content` rule in index.css neutralizes any
+ * page-level `min-h-screen` so the footer sits at the viewport bottom on short
+ * content and is pushed down (never overlapped) on long content — independent of
+ * each page's internals (the per-screen `min-h-screen` cleanup is retrofit #94).
+ */
+export function AppLayout() {
+  return (
+    <div className="flex min-h-screen flex-col bg-page">
+      <Header />
+      <div className="app-shell-content flex flex-1 flex-col">
+        <Outlet />
+      </div>
+      <Footer />
+    </div>
+  )
+}

--- a/client/src/components/Completion.tsx
+++ b/client/src/components/Completion.tsx
@@ -62,17 +62,12 @@ export function Completion({ title, totalPoints, multiplier, size, minutes }: Co
         <p className="text-sm text-gray-400">Current daily bonus: {+multiplier.toFixed(2)}x</p>
       )}
 
-      <div className="mt-2 flex flex-col gap-3">
-        <Link
-          to={keepGoingHref}
-          className="rounded-xl bg-[#D85A30] px-8 py-3 text-lg font-semibold text-white transition hover:bg-[#c24d27]"
-        >
-          Keep going
-        </Link>
-        <Link to="/" className="text-sm text-gray-500 underline hover:text-gray-700">
-          Back to home
-        </Link>
-      </div>
+      <Link
+        to={keepGoingHref}
+        className="mt-2 rounded-xl bg-[#D85A30] px-8 py-3 text-lg font-semibold text-white transition hover:bg-[#c24d27]"
+      >
+        Keep going
+      </Link>
     </main>
   )
 }

--- a/client/src/components/EmptyState.tsx
+++ b/client/src/components/EmptyState.tsx
@@ -34,9 +34,6 @@ export function EmptyState({ filtered = false }: { filtered?: boolean }) {
         >
           {filtered ? 'Add a task' : 'Choose a win'}
         </Link>
-        <Link to="/" className="text-sm text-gray-500 underline hover:text-gray-700">
-          Back home
-        </Link>
       </div>
     </main>
   )

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -1,0 +1,20 @@
+import { useAuth } from '@/auth/useAuth'
+
+/**
+ * Persistent app footer (visual refresh v2, #92). Minimal, centered, flat white.
+ * This is the ONE home for logout across every authed screen (it moved here from
+ * Home so it's consistent everywhere).
+ */
+export function Footer() {
+  const { logout } = useAuth()
+
+  return (
+    <footer className="flex items-center justify-center gap-3 bg-surface px-4 py-4 text-xs text-muted">
+      <span>© AddiApp</span>
+      <span aria-hidden="true">·</span>
+      <button type="button" onClick={() => void logout()} className="font-medium hover:text-primary">
+        Log out
+      </button>
+    </footer>
+  )
+}

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -1,0 +1,80 @@
+import { Link, useLocation } from 'react-router-dom'
+import { LayoutGrid, Play, Plus, type LucideIcon } from 'lucide-react'
+import { useAuth } from '@/auth/useAuth'
+import type { AuthUser } from '@/auth/authContext'
+
+/** 1–2 uppercase initials from the display name, falling back to the email. */
+function initialsFor(user: AuthUser): string {
+  const name = user.displayName?.trim()
+  if (name) {
+    const [first, second] = name.split(/\s+/)
+    return (first[0] + (second?.[0] ?? '')).toUpperCase()
+  }
+  return user.email[0]!.toUpperCase()
+}
+
+/** Icon-only nav; a section stays active across its sub-routes. */
+const NAV: { to: string; label: string; Icon: LucideIcon; match: (p: string) => boolean }[] = [
+  { to: '/', label: 'Play', Icon: Play, match: (p) => p === '/' || p.startsWith('/play') },
+  { to: '/dashboard', label: 'Dashboard', Icon: LayoutGrid, match: (p) => p.startsWith('/dashboard') },
+]
+
+/**
+ * Persistent app header (visual refresh v2, #92). Flat white bar — separated
+ * from the cream page by colour alone (no shadow, no border). Wordmark far left;
+ * on the right, one grouped cluster: icon-only nav (colour = state, no label/bg),
+ * a filled "Add task" CTA, and the initials avatar (which links to the user's
+ * stats page — there is no separate "Stats" nav item).
+ */
+export function Header() {
+  const { user } = useAuth()
+  const { pathname } = useLocation()
+
+  return (
+    <header className="flex items-center justify-between gap-4 bg-surface px-4 py-3 sm:px-6">
+      <Link to="/" className="text-xl font-bold tracking-tight text-gray-900">
+        Addi<span className="text-primary">App</span>
+      </Link>
+
+      <div className="flex items-center gap-4 sm:gap-5">
+        <nav className="flex items-center gap-4">
+          {NAV.map(({ to, label, Icon, match }) => {
+            const active = match(pathname)
+            return (
+              <Link
+                key={to}
+                to={to}
+                aria-label={label}
+                title={label}
+                aria-current={active ? 'page' : undefined}
+                className={active ? 'text-primary' : 'text-muted hover:text-gray-900'}
+              >
+                <Icon className="h-6 w-6" strokeWidth={2} />
+              </Link>
+            )
+          })}
+        </nav>
+
+        <Link
+          to="/tasks/new"
+          className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-sm font-semibold text-white transition hover:opacity-90"
+        >
+          <Plus className="h-4 w-4" strokeWidth={2.5} />
+          <span className="hidden sm:inline">Add task</span>
+        </Link>
+
+        {user && (
+          <Link
+            to="/stats"
+            aria-label="Your stats"
+            aria-current={pathname.startsWith('/stats') ? 'page' : undefined}
+            title={user.displayName ?? user.email}
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary text-sm font-bold text-white transition hover:opacity-90"
+          >
+            {initialsFor(user)}
+          </Link>
+        )}
+      </div>
+    </header>
+  )
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,1 +1,37 @@
 @import 'tailwindcss';
+
+/*
+ * AddiApp design tokens (visual refresh v2, #91/#92). Single source of truth.
+ * Tailwind v4 `@theme` generates the `bg-*` / `text-*` / `bg-*-tint` utilities
+ * AND exposes `--color-*` CSS vars (for raw-CSS / SVG fills like the Mascot).
+ * All values are WCAG AA (4.5:1) verified for their text use — see #91.
+ *
+ * Hard rules (see #91): no box-shadow, no borders — surfaces separate from the
+ * cream page by flat color alone. `#D85A30` (old coral) is fully retired.
+ */
+@theme {
+  --color-primary: #c43a0c;
+  --color-primary-tint: #fdf0ea;
+  --color-success: #0b7c63;
+  --color-success-tint: #e5f5f0;
+  --color-accent: #6e3fd6;
+  --color-accent-tint: #f1ebfd;
+  --color-warning: #d98a00;
+  --color-muted: #5b6270;
+  --color-page: #f6f1ea;
+  --color-surface: #ffffff;
+}
+
+/*
+ * The AppLayout shell owns page height (#92). Pages still set their own
+ * `min-h-screen` (per-screen cleanup is retrofit #94); inside the shell that
+ * would stack a full viewport UNDER the header+footer and push the footer off
+ * screen. This neutralizes the page's min-height and lets it flex to fill the
+ * content row instead — footer sits at the viewport bottom on short content and
+ * is pushed down (never overlapped) on long content. Unlayered, so it wins over
+ * the Tailwind `min-h-screen` utility (which lives in a cascade layer).
+ */
+.app-shell-content > * {
+  flex: 1 1 auto;
+  min-height: 0;
+}

--- a/client/src/pages/AddTask.tsx
+++ b/client/src/pages/AddTask.tsx
@@ -42,9 +42,6 @@ export function AddTask() {
           >
             Let&apos;s play
           </Link>
-          <Link to="/" className="text-sm text-gray-500 underline hover:text-gray-700">
-            Back home
-          </Link>
         </div>
       </main>
     )
@@ -55,13 +52,10 @@ export function AddTask() {
       <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-sm">
         <h1 className="mb-5 text-center text-2xl font-bold text-gray-800">Add a task</h1>
         <TaskForm key={formKey} submitLabel="Add task" submittingLabel="Adding…" onSubmit={onSubmit} />
-        <div className="mt-4 flex justify-between text-sm">
+        <div className="mt-4 text-center text-sm">
           <button onClick={() => navigate(-1)} className="text-gray-500 underline hover:text-gray-700">
             Cancel
           </button>
-          <Link to="/" className="text-gray-500 underline hover:text-gray-700">
-            Home
-          </Link>
         </div>
       </div>
     </main>

--- a/client/src/pages/Choice.tsx
+++ b/client/src/pages/Choice.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import { Mascot } from '@/components/Mascot'
 import type { WinSize } from '@/lib/tasks'
 
@@ -73,10 +73,6 @@ export function Choice() {
           <div className="text-sm text-gray-600">Real progress worth more points</div>
         </button>
       </div>
-
-      <Link to="/" className="text-sm text-gray-500 underline hover:text-gray-700">
-        Back home
-      </Link>
     </main>
   )
 }

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -183,22 +183,8 @@ export function Dashboard() {
 
   return (
     <main className="mx-auto min-h-screen max-w-4xl p-4 sm:p-8">
-      <header className="mb-6 flex flex-wrap items-center justify-between gap-3">
+      <header className="mb-6">
         <h1 className="text-2xl font-bold text-gray-800">Dashboard</h1>
-        <div className="flex items-center gap-2">
-          <Link
-            to="/tasks/new"
-            className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
-          >
-            + Add task
-          </Link>
-          <Link
-            to="/play"
-            className="rounded-lg bg-[#D85A30] px-4 py-2 text-sm font-semibold text-white transition hover:bg-[#c24d27]"
-          >
-            ▶ Play
-          </Link>
-        </div>
       </header>
 
       <PointsCard refreshSignal={pointsRefresh} />
@@ -384,12 +370,6 @@ export function Dashboard() {
           </table>
         </div>
       )}
-
-      <div className="mt-6 text-center">
-        <Link to="/" className="text-sm text-gray-500 underline hover:text-gray-700">
-          Back home
-        </Link>
-      </div>
 
       {pendingTask && (
         <div className="fixed bottom-6 left-1/2 flex -translate-x-1/2 items-center gap-4 rounded-lg bg-gray-900 px-4 py-3 text-sm text-white shadow-lg">

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { useAuth } from '@/auth/useAuth'
 import { Mascot } from '@/components/Mascot'
 import { fetchTasks, type Task } from '@/lib/tasks'
 
@@ -22,7 +21,6 @@ function mostRecentlyStarted(tasks: Task[]): Task | null {
  * selection only offers backlog tasks, so this is the way back to an active one.
  */
 export function Home() {
-  const { user, logout } = useAuth()
   const [inProgress, setInProgress] = useState<Task[]>([])
 
   useEffect(() => {
@@ -34,54 +32,27 @@ export function Home() {
   const resume = mostRecentlyStarted(inProgress)
 
   return (
-    <main className="relative flex min-h-screen flex-col items-center justify-center gap-6 p-8 text-center">
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8 text-center">
       <Mascot mood="happy" />
       <h1 className="max-w-md text-3xl font-bold text-gray-800">
         Ready to do something great today?
       </h1>
 
       {resume && (
-        <div className="flex w-full max-w-sm flex-col items-center gap-1">
-          <Link
-            to={`/play/progress/${resume.id}`}
-            className="flex w-full items-center justify-center gap-2 rounded-xl border-2 border-[#F5A623] bg-[#F5A623]/10 px-6 py-3 font-semibold text-[#a06d00] transition hover:bg-[#F5A623]/20"
-          >
-            ▸ Resume: <span className="max-w-[16rem] truncate">{resume.title}</span>
-          </Link>
-          {inProgress.length > 1 && (
-            <Link to="/dashboard" className="text-xs text-gray-400 underline hover:text-gray-600">
-              {inProgress.length} tasks in progress
-            </Link>
-          )}
-        </div>
+        <Link
+          to={`/play/progress/${resume.id}`}
+          className="flex w-full max-w-sm items-center justify-center gap-2 rounded-xl border-2 border-[#F5A623] bg-[#F5A623]/10 px-6 py-3 font-semibold text-[#a06d00] transition hover:bg-[#F5A623]/20"
+        >
+          ▸ Resume: <span className="max-w-[16rem] truncate">{resume.title}</span>
+        </Link>
       )}
 
-      <div className="mt-2 flex flex-col items-center gap-3">
-        <Link
-          to="/play"
-          className="rounded-xl bg-[#D85A30] px-10 py-3 text-lg font-semibold text-white transition hover:bg-[#c24d27]"
-        >
-          Let&apos;s go
-        </Link>
-        <div className="flex gap-4 text-sm text-gray-500">
-          <Link to="/tasks/new" className="underline hover:text-gray-700">
-            Add a task
-          </Link>
-          <Link to="/dashboard" className="underline hover:text-gray-700">
-            Dashboard
-          </Link>
-          <Link to="/stats" className="underline hover:text-gray-700">
-            Stats
-          </Link>
-        </div>
-      </div>
-
-      <footer className="absolute bottom-6 flex flex-col items-center gap-1 text-xs text-gray-400">
-        <span>Signed in as {user?.displayName ?? user?.email}</span>
-        <button onClick={() => void logout()} className="underline hover:text-gray-600">
-          Log out
-        </button>
-      </footer>
+      <Link
+        to="/play"
+        className="mt-2 rounded-xl bg-[#D85A30] px-10 py-3 text-lg font-semibold text-white transition hover:bg-[#c24d27]"
+      >
+        Let&apos;s go
+      </Link>
     </main>
   )
 }

--- a/client/src/pages/InProgress.tsx
+++ b/client/src/pages/InProgress.tsx
@@ -197,9 +197,9 @@ export function InProgress() {
         </button>
       </div>
 
-      <Link to="/" className="text-sm text-gray-400 underline hover:text-gray-600">
-        Leave it running, go home
-      </Link>
+      <p className="text-sm text-gray-400">
+        You can leave any time — this task stays in progress until you complete it.
+      </p>
     </main>
   )
 }

--- a/client/src/pages/Stats.tsx
+++ b/client/src/pages/Stats.tsx
@@ -78,17 +78,6 @@ export function Stats() {
         {today.tasksCompleted} {today.tasksCompleted === 1 ? 'task' : 'tasks'}
       </p>
 
-      <div className="mt-6 flex justify-center gap-4 text-sm">
-        <Link to="/play" className="text-[#a8431f] underline hover:text-[#7f3217]">
-          Play
-        </Link>
-        <Link to="/dashboard" className="text-gray-500 underline hover:text-gray-700">
-          Dashboard
-        </Link>
-        <Link to="/" className="text-gray-500 underline hover:text-gray-700">
-          Home
-        </Link>
-      </div>
     </main>
   )
 }

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -14,6 +14,7 @@ import { Dashboard } from '@/pages/Dashboard'
 import { Stats } from '@/pages/Stats'
 import { NotFound } from '@/pages/NotFound'
 import { ProtectedRoute } from '@/components/ProtectedRoute'
+import { AppLayout } from '@/components/AppLayout'
 
 export const router = createBrowserRouter([
   { path: '/login', element: <Login /> },
@@ -22,16 +23,23 @@ export const router = createBrowserRouter([
   { path: '/forgot-password', element: <ForgotPassword /> },
   { path: '/reset', element: <ResetPassword /> },
   {
+    // ProtectedRoute gates; AppLayout wraps every authed route in the shared
+    // Header/Footer shell at one seam (visual refresh v2, #92).
     element: <ProtectedRoute />,
     children: [
-      { path: '/', element: <Home /> },
-      { path: '/play', element: <Choice /> },
-      { path: '/play/task', element: <TaskPresented /> },
-      { path: '/play/progress/:id', element: <InProgress /> },
-      { path: '/tasks/new', element: <AddTask /> },
-      { path: '/tasks/:id/edit', element: <EditTask /> },
-      { path: '/dashboard', element: <Dashboard /> },
-      { path: '/stats', element: <Stats /> },
+      {
+        element: <AppLayout />,
+        children: [
+          { path: '/', element: <Home /> },
+          { path: '/play', element: <Choice /> },
+          { path: '/play/task', element: <TaskPresented /> },
+          { path: '/play/progress/:id', element: <InProgress /> },
+          { path: '/tasks/new', element: <AddTask /> },
+          { path: '/tasks/:id/edit', element: <EditTask /> },
+          { path: '/dashboard', element: <Dashboard /> },
+          { path: '/stats', element: <Stats /> },
+        ],
+      },
     ],
   },
   { path: '*', element: <NotFound /> },

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
       "name": "@addiapp/client",
       "version": "0.0.0",
       "dependencies": {
+        "lucide-react": "^1.24.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.1.1"
@@ -3363,6 +3364,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.24.0.tgz",
+      "integrity": "sha512-YT6mBD8lGKkg4nM39enlm94/sfJIiW0YKUT60fBy4YK8tai31ylg1VhGNWxkpSKHo9UagfnZqwIff3HTDQwXeA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {


### PR DESCRIPTION
## Summary
Visual refresh v2 foundation (#91): @theme design tokens (10 AA-verified colors, cream page/white surfaces, no shadows/borders), a persistent Header/Footer/AppLayout shell wired at the ProtectedRoute seam (auth pages stay shell-less), icon-only header nav via lucide-react (Play/Dashboard color-by-state + filled Add-task CTA + avatar→/stats), a shell-level height fix so the footer sits correctly on short and long content, and a sweep removing in-page nav made redundant by the global header. Per-screen re-skin (old coral/borders/shadows, Stats emoji→icons) remains #94. Verified live via headless Chrome across all authed screens + auth pages.

## Changes
- #92 - Visual refresh v2 (A): design tokens + Header/Footer shell + icon nav

Closes #92