### PR TITLE
Promote develop → main

### DIFF
--- a/.changes/unreleased/87-nightly-mysqldump-backup-cron-for-addiapp.md
+++ b/.changes/unreleased/87-nightly-mysqldump-backup-cron-for-addiapp.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Added -->
+- Nightly mysqldump backup cron for addiapp_prod (app-level DB backup) ([#87](https://github.com/neturely/addiapp/issues/87))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,98 @@
+name: CI
+
+# Release gate. By design this runs ONLY on the develop -> main promotion PR, not
+# on the small, frequent issue PRs into develop — those don't wait on CI; the
+# promotion PR is where the full suite (lint/typecheck/build + PHPUnit) runs
+# together and any issues get fixed via review before the release merges.
+#
+# This workflow only REPORTS status; blocking the merge requires branch protection
+# to mark these checks "required" — on MAIN ONLY (never develop, where CI doesn't
+# run, so a required check would never resolve). See docs/DEPLOY.md.
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch: # allow running the full suite manually on demand
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend:
+    name: Backend (PHPUnit + php -l)
+    runs-on: ubuntu-latest
+
+    # Prod is MariaDB 10.11 — test against the same flavour for fidelity (the code
+    # special-cases MariaDB/MySQL divergences elsewhere).
+    services:
+      mariadb:
+        image: mariadb:10.11
+        env:
+          MARIADB_ROOT_PASSWORD: root
+          MARIADB_DATABASE: addiapp_test
+          MARIADB_USER: addiapp
+          MARIADB_PASSWORD: addiapp
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=10
+
+    env:
+      DATABASE_URL: mysql://addiapp:addiapp@127.0.0.1:3306/addiapp_test
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP 8.2
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: pdo_mysql
+          coverage: none
+          tools: composer:v2
+
+      - name: Cache Composer packages
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: composer-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-
+
+      - name: Install dev dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Syntax lint (php -l) across api/
+        run: find api -name '*.php' -print0 | xargs -0 -n1 -P4 php -l
+
+      - name: Migrate the test database
+        run: php api/migrate.php
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit
+
+  frontend:
+    name: Frontend (lint + typecheck + build)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build -w client

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,11 @@ dist/
 api/config.php
 api/vendor/
 
+# Dev-only test tooling (Composer/PHPUnit live at the repo root, never deployed)
+/vendor/
+.phpunit.cache/
+.phpunit.result.cache
+
 # logs
 *.log
 npm-debug.log*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,7 +223,12 @@ badges/tags — not a literal Duolingo green, not yet locked as final brand pale
   client-side routing and skips `/api`.
 - Secrets on the server: `~/api/config.php` (DB creds, `RESEND_API_KEY`, `appUrl`,
   `emailFrom`, `isProd`). GitHub secrets: `DEPLOY_SSH_{HOST,USER,PORT,KEY}`.
-- Full details + one-time server setup: **docs/DEPLOY.md**.
+- **DB backups (OPS-1)**: nightly `mysqldump` cron (`scripts/backup-db.sh`) →
+  gzipped/timestamped dumps in `~/backups/db/`, ~14-day rotation, read-only
+  `addiapp_bak` user. App-level — JetBackup doesn't expose DB restore points on
+  this account. `~/backups/db/` is the handoff for an external NAS pull (separate
+  repo; not built here). Cron install is a documented on-box step, not deployed.
+- Full details + one-time server setup + backups: **docs/DEPLOY.md**.
 
 ## How to help me
 

--- a/api/src/Points/Award.php
+++ b/api/src/Points/Award.php
@@ -70,6 +70,13 @@ final class Award
             throw $e;
         }
 
+        // NOTE (TECH-2): `daily_stats.multiplier` stores $liveMultiplier — the
+        // multiplier the *next* completion will earn — NOT the one applied to the
+        // completion just recorded. It's a live preview for the UI (the points card
+        // shows "your next task earns ×N"). The multiplier actually applied to THIS
+        // completion is persisted per-row in `points_log.multiplier` above. So a
+        // reader inspecting daily_stats will see a value one step ahead of the last
+        // award; that's intentional, not a bug.
         $pdo->prepare(
             'INSERT INTO daily_stats (user_id, stat_date, tasks_completed, points_earned, multiplier)
              VALUES (?, ?, 1, ?, ?)

--- a/api/src/Tasks/Selection.php
+++ b/api/src/Tasks/Selection.php
@@ -64,7 +64,13 @@ final class Selection
     {
         $rng ??= static fn (): float => mt_rand() / mt_getrandmax();
         $count = count($candidates);
-        return $count === 0 ? null : $candidates[(int) floor($rng() * $count)];
+        if ($count === 0) {
+            return null;
+        }
+        // Clamp: the default rng can return exactly 1.0 (mt_rand() == mt_getrandmax()),
+        // which would otherwise index one past the end.
+        $index = min((int) floor($rng() * $count), $count - 1);
+        return $candidates[$index];
     }
 
     /** @return array<string,callable> name → strategy */

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,23 @@
+{
+    "name": "neturely/addiapp-tests",
+    "description": "Dev-only test tooling for the AddiApp PHP API. Never deployed — the api/ tree stays dependency-free; this lives at the repo root and vendor/ is gitignored.",
+    "license": "MIT",
+    "type": "project",
+    "require-dev": {
+        "phpunit/phpunit": "^11.5"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "platform": {
+            "php": "8.2.0"
+        },
+        "sort-packages": true
+    },
+    "scripts": {
+        "test": "phpunit"
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,1786 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "16247cb9ff82f162716f4189693af1ab",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
+            },
+            "time": "2026-07-04T14:30:18+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "11.0.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.2",
+                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-text-template": "^4.0.1",
+                "sebastian/code-unit-reverse-lookup": "^4.0.1",
+                "sebastian/complexity": "^4.0.1",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/lines-of-code": "^3.0.1",
+                "sebastian/version": "^5.0.2",
+                "theseer/tokenizer": "^1.3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5.46"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "11.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.12"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-24T07:01:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-02T13:52:54+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^11.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:07:44+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:08:43+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "7.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:09:35+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "11.5.56",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "5f83edffa6967c3db468d48a695ec7bcb02e9256"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5f83edffa6967c3db468d48a695ec7bcb02e9256",
+                "reference": "5f83edffa6967c3db468d48a695ec7bcb02e9256",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.2",
+                "phpunit/php-code-coverage": "^11.0.12",
+                "phpunit/php-file-iterator": "^5.1.1",
+                "phpunit/php-invoker": "^5.0.1",
+                "phpunit/php-text-template": "^4.0.1",
+                "phpunit/php-timer": "^7.0.1",
+                "sebastian/cli-parser": "^3.0.2",
+                "sebastian/code-unit": "^3.0.3",
+                "sebastian/comparator": "^6.3.3",
+                "sebastian/diff": "^6.0.2",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/exporter": "^6.3.2",
+                "sebastian/global-state": "^7.0.2",
+                "sebastian/object-enumerator": "^6.0.1",
+                "sebastian/recursion-context": "^6.0.3",
+                "sebastian/type": "^5.1.3",
+                "sebastian/version": "^5.0.2",
+                "staabm/side-effects-detector": "^1.0.5"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "11.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.56"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
+                }
+            ],
+            "time": "2026-07-06T14:52:39+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:41:36+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-19T07:56:08+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/183a9b2632194febd219bb9246eee421dad8d45e",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:45:54+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "6.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/diff": "^6.0",
+                "sebastian/exporter": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.4"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:26:40+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/ee41d384ab1906c68852636b6de493846e13e5a0",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:49:50+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "6.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:53:05+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "7.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/7.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-05-21T11:55:47+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "6.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/70a298763b40b213ec087c51c739efcaa90bcd74",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:12:51+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "7.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/3be331570a721f9a4b5917f4209773de17f747d7",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:57:36+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:58:38+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "6.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f5b498e631a74204185071eb41f33f38d64608aa",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:00:13+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:01:32+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "6.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-13T04:42:22+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "5.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/5.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-09T06:55:48+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "5.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/5.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-09T05:16:32+00:00"
+        },
+        {
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.2.0"
+    },
+    "plugin-api-version": "2.9.0"
+}

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -23,6 +23,67 @@ Runs on push to `main` (or manual dispatch):
 | `DEPLOY_SSH_PORT` | `22` |
 | `DEPLOY_SSH_KEY`  | private half of a dedicated deploy keypair (public half in the account's `~/.ssh/authorized_keys`) |
 
+## CI release gate (`.github/workflows/ci.yml`)
+
+Separate from deploy. By design it runs on **PRs into `main` only** — i.e. the
+`develop → main` **promotion PR** — plus manual `workflow_dispatch`.
+
+- **backend** — MariaDB 10.11 service (prod flavour) → PHP 8.2 → `composer install`
+  → `php -l` sweep across `api/` → migrate `addiapp_test` → PHPUnit.
+- **frontend** — Node 20 → `npm ci` → `lint` + `typecheck` + `build`.
+
+**Why not on develop?** For this project's size, the many small issue PRs into
+`develop` shouldn't each wait on CI. The promotion PR is the real release gate:
+the full suite runs there together and anything red gets fixed via review comments
+before the release merges. There is deliberately **no** CI on develop PRs, on
+pushes to develop, or on push-to-main (main only advances through the promotion PR,
+which already ran the suite; and `deploy.yml` rebuilds the SPA on push to main
+regardless, so a broken build still can't ship).
+
+The test tooling (Composer, `phpunit.xml`, `tests/`, `vendor/`) lives at the repo
+**root** and is git-ignored / never rsynced — the deployed `api/` tree stays
+dependency-free.
+
+### ⚠ Manual branch protection (one-time, required to actually block merges)
+
+The workflow only *reports* status. To make a red CI **block the merge**, the two
+checks must be marked **required**. Protection here is managed by an **org-level
+ruleset** (`neturely` → **"Branch Rules"**) that already targets both
+`refs/heads/develop` and `refs/heads/main` and enforces: no deletion, no
+force-push, PR required, review-thread resolution. It does **not** yet require
+status checks — that's the piece to add.
+
+> ⚠ **Apply required status checks to `main` ONLY — never `develop`.** CI does not
+> run on develop PRs, so a check required there would never report and would block
+> every develop merge outright. Because the org "Branch Rules" ruleset covers both
+> branches with one shared condition, add the status-check requirement as a
+> **separate ruleset scoped to `refs/heads/main`** (or split the rule) rather than
+> putting it on the shared one.
+
+1. GitHub → **org `neturely` → Settings → Rules → Rulesets** → add/edit a ruleset
+   whose target ref is **`refs/heads/main` only**.
+2. Add a **Require status checks to pass** rule and select the two checks:
+   **`Backend (PHPUnit + php -l)`** and **`Frontend (lint + typecheck + build)`**.
+   (They appear in the picker after `ci.yml` has run at least once.)
+3. Recommended: also tick **Require branches to be up to date before merging**.
+
+Requires org-admin (`admin:org`) to edit — it's an org ruleset, not a repo
+setting.
+
+### Running the backend tests locally
+
+```bash
+composer install                                   # one-time (repo root)
+docker exec addiapp-mysql-1 mysql -uroot -prootpassword \
+  -e "CREATE DATABASE IF NOT EXISTS addiapp_test; \
+      GRANT ALL ON addiapp_test.* TO 'addiapp'@'%'; FLUSH PRIVILEGES;"
+DATABASE_URL="mysql://addiapp:addiapp@127.0.0.1:3306/addiapp_test" php api/migrate.php
+DATABASE_URL="mysql://addiapp:addiapp@127.0.0.1:3306/addiapp_test" vendor/bin/phpunit
+```
+
+Without `DATABASE_URL` the pure-math/selection unit tests still run; the DB-backed
+tests skip (they never touch dev/prod data).
+
 ## One-time server setup
 
 1. **MySQL** (cPanel → MySQL Databases, or `uapi Mysql …` over SSH): create DB

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -50,3 +50,107 @@ Runs on push to `main` (or manual dispatch):
 in Resend (#65) before live sends work — until then registration succeeds but
 verification emails aren't delivered (logged as best-effort failures). Set
 `emailFrom` to a verified-domain sender once #65 is done.
+
+## Backups
+
+`addiapp_prod` is backed up at the **application level**, independent of
+KnownHost's JetBackup. JetBackup does **not** expose database restore points on
+this account (cPanel → JetBackup → Databases tab is empty), so the DB must be
+backed up ourselves. A nightly `mysqldump` (`scripts/backup-db.sh`) writes a
+consistent, gzipped, timestamped dump to `~/backups/db/`; an external NAS pull
+(separate repo) handles offsite retention.
+
+> **JetBackup at the host level** — the empty cPanel Databases tab only proves DB
+> restore points aren't exposed to *this* cPanel account. Whether JetBackup runs
+> DB backups at the WHM/root level (just not surfaced to this reseller tier) can't
+> be determined from a normal cPanel-user SSH session — it's an **open question
+> for a KnownHost support ticket**. This app-level backup stands on its own
+> regardless of the answer.
+
+### What the script does
+
+`scripts/backup-db.sh` (run from cron):
+
+- `mysqldump --single-transaction --quick` — consistent InnoDB snapshot with **no
+  table locking**, so the nightly dump never blocks the live app. The box runs
+  **MariaDB 10.11**, so the MySQL-only `--set-gtid-purged` (MariaDB errors
+  `unknown variable`) and `--no-tablespaces` (only needed for a MySQL 8
+  PROCESS-privilege quirk) are deliberately **not** passed.
+- Writes to `…​.sql.gz.tmp`, then `mv` to the final name (**atomic** on the same
+  filesystem) so the offsite pull never grabs a half-written gzip.
+- Emits a `.sha256` sidecar per dump for integrity verification.
+- Rotates: keeps ~14 daily dumps (`-mtime +14`), prunes older files + sidecars.
+- `set -euo pipefail` + `gzip -t` self-check; failures exit non-zero and hit
+  stderr (→ cron `MAILTO`).
+
+### One-time setup
+
+The deploy rsync only ships `client/dist` + `api/`, so the script is installed by
+hand (like `config.php`). All steps run on the box (`ssh addiapp@209.42.255.1`).
+
+1. **Dedicated read-only DB user.** In cPanel → *MySQL® Databases* create user
+   `addiapp_bak` (cPanel prefixes it to the account, matching `addiapp_prod`),
+   then *Add User To Database* → grant only **SELECT, LOCK TABLES, SHOW VIEW** on
+   `addiapp_prod`. (Least-privilege: a leaked credential can't mutate or drop
+   data.) Equivalent SQL if you have direct access:
+   ```sql
+   CREATE USER 'addiapp_bak'@'localhost' IDENTIFIED BY 'STRONG_PASSWORD';
+   GRANT SELECT, LOCK TABLES, SHOW VIEW ON `addiapp_prod`.* TO 'addiapp_bak'@'localhost';
+   ```
+2. **Credentials file** `~/backups/.my.cnf` (never on the command line — that's
+   visible in `ps`):
+   ```ini
+   [client]
+   user=addiapp_bak
+   password=STRONG_PASSWORD
+   host=localhost
+   ```
+   ```bash
+   mkdir -p ~/backups/db ~/bin
+   chmod 600 ~/backups/.my.cnf
+   ```
+3. **Install the script** (copy `scripts/backup-db.sh` from the repo to the box):
+   ```bash
+   # from a checkout, or scp the file up:
+   install -m 755 scripts/backup-db.sh ~/bin/backup-db.sh
+   ```
+4. **Crontab** (`crontab -e`) — nightly at 03:30 server time. `MAILTO` sends
+   failures to you (stdout → log, stderr → mail), so a broken backup is noticed:
+   ```cron
+   MAILTO="you@example.com"
+   30 3 * * * /home/addiapp/bin/backup-db.sh >> /home/addiapp/backups/db/backup.log
+   ```
+
+### Offsite handoff (external — not built here)
+
+Offsite retention is a **separate NAS-based pull** tracked in a different repo.
+The contract this repo guarantees at the handoff point:
+
+- **Directory:** `~/backups/db/` (i.e. `/home/addiapp/backups/db/`).
+- **Filename pattern:** `addiapp_prod-YYYY-MM-DD.sql.gz` + `addiapp_prod-YYYY-MM-DD.sql.gz.sha256`.
+- Final filenames only appear once fully written (atomic `mv`), so a pull can
+  safely grab any file matching the pattern and verify it against its `.sha256`.
+- On-server retention is ~14 days — the pull must run at least that often or a
+  day's dump is pruned before it's copied.
+
+Do **not** build the NAS/offsite side in this repo.
+
+### Verify (run once after setup)
+
+```bash
+~/bin/backup-db.sh                                  # run manually
+ls -la ~/backups/db/                                # expect the .sql.gz + .sha256
+gzip -t ~/backups/db/addiapp_prod-*.sql.gz && echo "gzip OK"
+cd ~/backups/db && sha256sum -c addiapp_prod-*.sql.gz.sha256
+zcat ~/backups/db/addiapp_prod-*.sql.gz | grep -c 'CREATE TABLE'   # expect 8
+```
+
+The `CREATE TABLE` count is **8** — the 7 schema tables (`users`, `sessions`,
+`tasks`, `points_log`, `daily_stats`, `email_tokens`, `rate_limits`) plus the
+`_migrations` tracker. Strongest check (optional — needs a scratch DB you can
+create via cPanel, as `addiapp_bak` can't `CREATE DATABASE`):
+
+```bash
+zcat ~/backups/db/addiapp_prod-*.sql.gz | mysql addiapp_restore_test
+mysql addiapp_restore_test -e "SHOW TABLES; SELECT COUNT(*) FROM users;"
+```

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache"
+         failOnWarning="true"
+         failOnRisky="true"
+         beStrictAboutOutputDuringTests="true">
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="db">
+            <directory>tests/Db</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>api/src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# =============================================================================
+# backup-db.sh — nightly backup of the addiapp_prod MySQL database.
+#
+# Runs on the KnownHost box from cron (see docs/DEPLOY.md § Backups). Writes a
+# consistent, gzipped, timestamped dump to ~/backups/db/ with a .sha256 sidecar,
+# then prunes dumps older than RETENTION_DAYS. ~/backups/db/ is the handoff point
+# for the external offsite pull (a separate NAS-based job, tracked elsewhere).
+#
+# This is the app-level DB backup — independent of KnownHost's JetBackup, which
+# does not expose database restore points on this account (see DEPLOY.md).
+#
+# Credentials come from ~/backups/.my.cnf (chmod 600) — a dedicated READ-ONLY
+# MySQL user (addiapp_bak) — and are passed via --defaults-extra-file, never on
+# the command line (which would be visible in `ps`).
+#
+# Install + verification: docs/DEPLOY.md § Backups. Not shipped by the deploy
+# rsync (which only syncs client/dist + api/); copy it to the box once.
+# =============================================================================
+set -euo pipefail
+
+# --- config ------------------------------------------------------------------
+DB_NAME="addiapp_prod"
+BACKUP_DIR="${HOME}/backups/db"
+DEFAULTS_FILE="${HOME}/backups/.my.cnf"
+RETENTION_DAYS=14
+
+# cron runs with a minimal PATH; make sure the tools resolve on cPanel/CloudLinux.
+export PATH="/usr/local/bin:/usr/bin:/bin:${PATH:-}"
+
+# --- dump --------------------------------------------------------------------
+stamp="$(date +%F)" # YYYY-MM-DD, server-local time
+base="${DB_NAME}-${stamp}.sql.gz"
+final="${BACKUP_DIR}/${base}"
+tmp="${final}.tmp"
+
+mkdir -p "${BACKUP_DIR}"
+
+# The production box runs MariaDB 10.11 (not MySQL). --single-transaction --quick
+# gives a consistent InnoDB snapshot with NO table locks, so the nightly dump
+# never blocks the live app — the one flag that matters here.
+#
+# Deliberately NOT passed (MySQL-only; MariaDB's mysqldump rejects/doesn't need them):
+#   --set-gtid-purged  → MySQL-only GTID handling; MariaDB errors "unknown variable".
+#   --no-tablespaces   → only dodges a MySQL 8 PROCESS-privilege quirk that MariaDB
+#                        doesn't have.
+mysqldump \
+  --defaults-extra-file="${DEFAULTS_FILE}" \
+  --single-transaction \
+  --quick \
+  "${DB_NAME}" \
+  | gzip -c > "${tmp}"
+
+# Atomic publish: the offsite pull reads this directory, so the final filename
+# must only ever appear once the file is complete. mv on the same fs is atomic.
+mv "${tmp}" "${final}"
+
+# Integrity sidecar for the offsite pull (and our own verification) to check.
+( cd "${BACKUP_DIR}" && sha256sum "${base}" > "${base}.sha256" )
+
+# Self-check: fail loudly (cron MAILTO surfaces stderr) if the gzip is corrupt.
+gzip -t "${final}"
+
+# --- rotation ----------------------------------------------------------------
+# Keep ~RETENTION_DAYS daily dumps (and their .sha256 sidecars); prune older.
+find "${BACKUP_DIR}" -type f -name "${DB_NAME}-*.sql.gz*" -mtime "+${RETENTION_DAYS}" -delete
+
+echo "[addiapp-backup] $(date '+%F %T') wrote ${final} ($(du -h "${final}" | cut -f1))"

--- a/tests/Db/AwardTest.php
+++ b/tests/Db/AwardTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Db;
+
+use App\Points\Award;
+
+/**
+ * Tier-1 DB regression for award-once idempotency (#74) — the single most
+ * important invariant: a task's completion is scored exactly once, ever, even if
+ * the complete endpoint fires twice. Enforced by UNIQUE(task_id) on points_log.
+ */
+final class AwardTest extends DbTestCase
+{
+    public function testFirstAwardReturnsSpecBreakdown(): void
+    {
+        $userId = $this->makeUser('award-first@test.local');
+        $taskId = $this->makeTask($userId, 'high', 30);
+
+        // High (base 10), done in 15 of 30 min (speed bonus 10), 1st of the day
+        // (multiplier 1.00) => total 20.
+        $result = Award::awardTaskCompletion($taskId, $userId, 'high', 30, 15);
+
+        self::assertNotNull($result);
+        self::assertSame(10, $result['basePoints']);
+        self::assertSame(10, $result['speedBonus']);
+        self::assertSame(1.0, $result['multiplier']);
+        self::assertSame(20, $result['totalPoints']);
+    }
+
+    public function testSecondAwardOfSameTaskIsNoOp(): void
+    {
+        $userId = $this->makeUser('award-dupe@test.local');
+        $taskId = $this->makeTask($userId, 'medium', 20);
+
+        $first = Award::awardTaskCompletion($taskId, $userId, 'medium', 20, null);
+        $second = Award::awardTaskCompletion($taskId, $userId, 'medium', 20, null);
+
+        self::assertNotNull($first);
+        self::assertNull($second, 'a re-complete must not re-award');
+
+        // Exactly one ledger row for the task, and the daily rollup counted once.
+        $rows = $this->pdo->prepare('SELECT COUNT(*) FROM points_log WHERE task_id = ?');
+        $rows->execute([$taskId]);
+        self::assertSame(1, (int) $rows->fetchColumn());
+
+        $done = $this->pdo->prepare('SELECT tasks_completed FROM daily_stats WHERE user_id = ?');
+        $done->execute([$userId]);
+        self::assertSame(1, (int) $done->fetchColumn());
+    }
+
+    public function testDailyMultiplierGrowsAcrossTasksSameDay(): void
+    {
+        $userId = $this->makeUser('award-mult@test.local');
+        $t1 = $this->makeTask($userId, 'low', 10);
+        $t2 = $this->makeTask($userId, 'low', 10);
+
+        $first = Award::awardTaskCompletion($t1, $userId, 'low', 10, null);
+        $second = Award::awardTaskCompletion($t2, $userId, 'low', 10, null);
+
+        // 1st task of the day earns x1.00, the 2nd earns x1.15.
+        self::assertSame(1.0, $first['multiplier']);
+        self::assertSame(1.15, $second['multiplier']);
+        // base 2, no speed bonus: round(2 * 1.15) = 2.
+        self::assertSame(2, $first['totalPoints']);
+        self::assertSame(2, $second['totalPoints']);
+
+        // daily_stats persists the LIVE (next) multiplier = multiplier(3) = 1.30.
+        $m = $this->pdo->prepare('SELECT multiplier FROM daily_stats WHERE user_id = ?');
+        $m->execute([$userId]);
+        self::assertSame('1.30', $m->fetchColumn());
+    }
+}

--- a/tests/Db/DbTestCase.php
+++ b/tests/Db/DbTestCase.php
@@ -21,7 +21,11 @@ abstract class DbTestCase extends TestCase
 
     protected function setUp(): void
     {
-        if (getenv('DATABASE_URL') === false) {
+        // Treat an empty/whitespace value as unset too: Config maps '' back to the
+        // DEFAULT (dev) DB URL, so running here would risk writing to the dev
+        // schema instead of the throwaway addiapp_test one.
+        $dbUrl = getenv('DATABASE_URL');
+        if ($dbUrl === false || trim($dbUrl) === '') {
             self::markTestSkipped('DATABASE_URL not set — DB tests need a migrated addiapp_test schema.');
         }
         $this->pdo = Db::pdo();

--- a/tests/Db/DbTestCase.php
+++ b/tests/Db/DbTestCase.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Db;
+
+use App\Db;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Base for DB-backed tests. Each test runs inside a transaction that is rolled
+ * back in tearDown, so tests never see each other's rows and the schema stays
+ * pristine. Point DATABASE_URL at a throwaway `addiapp_test` schema (already
+ * migrated) — the harness refuses to run without it, so a stray run can never
+ * touch dev/prod data.
+ */
+abstract class DbTestCase extends TestCase
+{
+    protected PDO $pdo;
+
+    protected function setUp(): void
+    {
+        if (getenv('DATABASE_URL') === false) {
+            self::markTestSkipped('DATABASE_URL not set — DB tests need a migrated addiapp_test schema.');
+        }
+        $this->pdo = Db::pdo();
+        $this->pdo->beginTransaction();
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->pdo) && $this->pdo->inTransaction()) {
+            $this->pdo->rollBack();
+        }
+    }
+
+    /** Create a user and return its id. */
+    protected function makeUser(string $email): int
+    {
+        $this->pdo->prepare(
+            'INSERT INTO users (email, password_hash, email_verified) VALUES (?, ?, 1)',
+        )->execute([$email, 'x']);
+        return (int) $this->pdo->lastInsertId();
+    }
+
+    /** Create a backlog task for a user and return its id. */
+    protected function makeTask(int $userId, string $complexity, int $estimatedMinutes): int
+    {
+        $this->pdo->prepare(
+            'INSERT INTO tasks (user_id, title, complexity, estimated_minutes) VALUES (?, ?, ?, ?)',
+        )->execute([$userId, 'test task', $complexity, $estimatedMinutes]);
+        return (int) $this->pdo->lastInsertId();
+    }
+}

--- a/tests/Unit/CalculateTest.php
+++ b/tests/Unit/CalculateTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Points\Calculate;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tier-1 regression for the pure points math. These values encode PROJECT_SPEC
+ * §7 (and PointsConfig's finalized constants); a formula change that drifts the
+ * numbers must fail here.
+ */
+final class CalculateTest extends TestCase
+{
+    public function testBasePointsByComplexity(): void
+    {
+        self::assertSame(2, Calculate::basePointsFor('low'));
+        self::assertSame(5, Calculate::basePointsFor('medium'));
+        self::assertSame(10, Calculate::basePointsFor('high'));
+    }
+
+    /**
+     * Speed bonus: 0 on/over estimate, +100% of base at <=50% of the estimate,
+     * linear in between, and saturated (can't be farmed past 50% faster).
+     *
+     * @return array<string,array{int,int,?int,int}>
+     */
+    public static function speedBonusCases(): array
+    {
+        return [
+            // base, estimated, actual, expected bonus
+            'spec worked example: high, 30->15 = ceiling' => [10, 30, 15, 10],
+            'exactly on estimate = 0'                     => [10, 30, 30, 0],
+            'over estimate = 0'                           => [10, 30, 45, 0],
+            'actual null (not tracked) = 0'               => [10, 30, null, 0],
+            'zero estimate guards against /0 = 0'         => [10, 0, 5, 0],
+            'saturation edge: exactly 50% = ceiling'      => [10, 40, 20, 10],
+            'just under 50% still ceiling'                => [10, 40, 19, 10],
+            'well under 50% saturates, no farming'        => [10, 30, 5, 10],
+            'linear midpoint: 25% saved = half ceiling'   => [10, 40, 30, 5],
+            'low base rounds: 25% saved of base 2'        => [2, 40, 30, 1],
+            'medium base, 50% saved = +100%'              => [5, 20, 10, 5],
+        ];
+    }
+
+    #[DataProvider('speedBonusCases')]
+    public function testComputeSpeedBonus(int $base, int $estimated, ?int $actual, int $expected): void
+    {
+        self::assertSame($expected, Calculate::computeSpeedBonus($base, $estimated, $actual));
+    }
+
+    /**
+     * Daily multiplier: 1 + (n-1)*0.15, capped at 2.0 — the cap is first reached
+     * at the 8th completion of the day.
+     *
+     * @return array<string,array{int,float}>
+     */
+    public static function multiplierCases(): array
+    {
+        return [
+            '1st task = 1.00'          => [1, 1.00],
+            '2nd task = 1.15'          => [2, 1.15],
+            '3rd task = 1.30'          => [3, 1.30],
+            '7th task = 1.90 (< cap)'  => [7, 1.90],
+            '8th task caps at 2.00'    => [8, 2.00],
+            '20th task stays at cap'   => [20, 2.00],
+            'n<=0 floors at 1.00'      => [0, 1.00],
+        ];
+    }
+
+    #[DataProvider('multiplierCases')]
+    public function testDailyMultiplier(int $n, float $expected): void
+    {
+        self::assertSame($expected, Calculate::dailyMultiplier($n));
+    }
+
+    public function testComputeTotalSpecWorkedExample(): void
+    {
+        // §7: high task (base 10), finished 50% early (speed 10), as the 3rd task
+        // of the day (multiplier 1.30) => round((10 + 10) * 1.30) = 26.
+        self::assertSame(26, Calculate::computeTotal(10, 10, 1.30));
+    }
+
+    public function testComputeTotalBaseline(): void
+    {
+        // No bonus, first task of the day: total == base.
+        self::assertSame(2, Calculate::computeTotal(2, 0, 1.00));
+        self::assertSame(10, Calculate::computeTotal(10, 0, 1.00));
+    }
+
+    public function testComputeTotalRoundsHalfUp(): void
+    {
+        // (5 + 0) * 1.15 = 5.75 -> 6.
+        self::assertSame(6, Calculate::computeTotal(5, 0, 1.15));
+    }
+}

--- a/tests/Unit/SelectionTest.php
+++ b/tests/Unit/SelectionTest.php
@@ -14,7 +14,11 @@ use PHPUnit\Framework\TestCase;
  */
 final class SelectionTest extends TestCase
 {
-    /** Oldest -> youngest by createdAt; ids intentionally NOT in age order. */
+    /**
+     * Deliberately NOT in age order (youngest is listed first) and the ids do NOT
+     * correlate with age — so a passing test can't be quietly relying on input
+     * order. By createdAt the oldest is id 10, then 20, then 30 (the youngest).
+     */
     private const CANDIDATES = [
         ['id' => 30, 'createdAt' => '2026-01-03 10:00:00'], // youngest
         ['id' => 10, 'createdAt' => '2026-01-01 10:00:00'], // oldest
@@ -83,6 +87,14 @@ final class SelectionTest extends TestCase
         // After no sorting, uniformRandom indexes the list as-is: rng*count floored.
         self::assertSame(30, Selection::uniformRandom(self::CANDIDATES, static fn (): float => 0.0)['id']);
         self::assertSame(20, Selection::uniformRandom(self::CANDIDATES, static fn (): float => 0.999)['id']);
+    }
+
+    public function testUniformRandomClampsRngEqualToOne(): void
+    {
+        // The default rng (mt_rand()/mt_getrandmax()) can return exactly 1.0, which
+        // would index one past the end — the index must clamp to the last element.
+        $picked = Selection::uniformRandom(self::CANDIDATES, static fn (): float => 1.0);
+        self::assertSame(20, $picked['id']); // last element of the (unsorted) list
     }
 
     public function testStrategiesMapExposesAllThree(): void

--- a/tests/Unit/SelectionTest.php
+++ b/tests/Unit/SelectionTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Tasks\Selection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tier-1 regression for the pure task-selection strategies. `$rng` is injectable
+ * precisely so these are deterministic — we drive it to the low and high ends to
+ * pin the weighting behaviour without relying on randomness.
+ */
+final class SelectionTest extends TestCase
+{
+    /** Oldest -> youngest by createdAt; ids intentionally NOT in age order. */
+    private const CANDIDATES = [
+        ['id' => 30, 'createdAt' => '2026-01-03 10:00:00'], // youngest
+        ['id' => 10, 'createdAt' => '2026-01-01 10:00:00'], // oldest
+        ['id' => 20, 'createdAt' => '2026-01-02 10:00:00'],
+    ];
+
+    public function testEmptyCandidatesReturnNull(): void
+    {
+        self::assertNull(Selection::weightedByAge([]));
+        self::assertNull(Selection::oldestFirst([]));
+        self::assertNull(Selection::uniformRandom([]));
+    }
+
+    public function testSingleCandidateShortCircuits(): void
+    {
+        $only = ['id' => 99, 'createdAt' => '2026-01-01 10:00:00'];
+        self::assertSame($only, Selection::weightedByAge([$only]));
+        self::assertSame($only, Selection::oldestFirst([$only]));
+    }
+
+    public function testOldestFirstIsDeterministicOldest(): void
+    {
+        $picked = Selection::oldestFirst(self::CANDIDATES);
+        self::assertSame(10, $picked['id']);
+    }
+
+    public function testOldestFirstTieBreaksByLowerId(): void
+    {
+        $sameInstant = [
+            ['id' => 5, 'createdAt' => '2026-01-01 10:00:00'],
+            ['id' => 3, 'createdAt' => '2026-01-01 10:00:00'],
+        ];
+        self::assertSame(3, Selection::oldestFirst($sameInstant)['id']);
+    }
+
+    public function testWeightedByAgeLowRngPicksOldest(): void
+    {
+        // r starts at 0, first subtraction (heaviest weight) drops below 0 -> index 0.
+        $picked = Selection::weightedByAge(self::CANDIDATES, static fn (): float => 0.0);
+        self::assertSame(10, $picked['id']); // oldest is the heaviest-weighted
+    }
+
+    public function testWeightedByAgeHighRngPicksYoungest(): void
+    {
+        // rng near 1 lands in the last (lightest) bucket -> youngest.
+        $picked = Selection::weightedByAge(self::CANDIDATES, static fn (): float => 0.999);
+        self::assertSame(30, $picked['id']);
+    }
+
+    public function testWeightedByAgeOldestIsMoreLikelyThanYoungest(): void
+    {
+        // Sweep the rng across [0,1); the oldest bucket must own more of the range
+        // than the youngest (rank-based weights 3:2:1 for three candidates).
+        $counts = [10 => 0, 20 => 0, 30 => 0];
+        for ($i = 0; $i < 60; $i++) {
+            $r = $i / 60;
+            $picked = Selection::weightedByAge(self::CANDIDATES, static fn (): float => $r);
+            $counts[$picked['id']]++;
+        }
+        self::assertGreaterThan($counts[30], $counts[10]);
+        self::assertGreaterThan($counts[20], $counts[10]);
+    }
+
+    public function testUniformRandomIndexesByRng(): void
+    {
+        // After no sorting, uniformRandom indexes the list as-is: rng*count floored.
+        self::assertSame(30, Selection::uniformRandom(self::CANDIDATES, static fn (): float => 0.0)['id']);
+        self::assertSame(20, Selection::uniformRandom(self::CANDIDATES, static fn (): float => 0.999)['id']);
+    }
+
+    public function testStrategiesMapExposesAllThree(): void
+    {
+        $names = array_keys(Selection::strategies());
+        self::assertSame(['weightedByAge', 'oldestFirst', 'uniformRandom'], $names);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * PHPUnit bootstrap. Wires two autoloaders:
+ *   - Composer's (PHPUnit itself + the Tests\ PSR-4 namespace), and
+ *   - the app's own dependency-free autoloader (App\ -> api/src), so the tests
+ *     exercise the SAME loader production uses — no Composer inside api/.
+ *
+ * DB-backed tests read DATABASE_URL from the environment (Config honours it).
+ * Point it at a throwaway `addiapp_test` schema; never at dev/prod data.
+ */
+
+require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../api/src/autoload.php';


### PR DESCRIPTION
Promotion: test infrastructure (no new user-facing features since v1.1.0).

Ships #124 (TECH-1):
- PHPUnit harness at the repo root (dev-only; vendor/ gitignored; the deployed api/ tree stays dependency-free).
- Tier-1 tests: pure points math (PROJECT_SPEC §7 worked examples), Selection strategies (deterministic rng), and award-once idempotency (DB, tx-rollback isolation).
- `.github/workflows/ci.yml` release gate — backend (MariaDB 10.11 + PHPUnit + `php -l`) and frontend (lint/typecheck/build). Runs on PRs into main only (this PR) + manual dispatch; intentionally no CI on develop.
- Folds the TECH-2 explanatory comment into Award.php (daily_stats.multiplier stores the next completion's live multiplier — intentional).
- docs/DEPLOY.md: CI release-gate + local test-run + org-ruleset branch-protection docs (required status checks belong on **main only**, never develop).

**This PR IS the first main-targeting CI run** — its checks are what the org ruleset's required-status-checks picker will list once green.

Fast-follows filed, not implemented: #128 (Tier 2 auth/session tests), #129 (Tier 3 integration test), both blocked_by #124.

Sanity: full test suite green (34 tests), frontend build green, /api/health 200. Only runtime api/ change is a comment — behaviourally identical to current production.

## Promoting (2 commits)
- Close #87 - Nightly mysqldump backup cron for addiapp_prod (app-level DB backup) (#88)
- Close #124 - TECH-1 — Test harness + CI merge gate + Tier-1 tests (#125)