### PR TITLE
Close #131 - TECH-1 promotion review fixes (Copilot on PR #130)

### DIFF
--- a/api/src/Tasks/Selection.php
+++ b/api/src/Tasks/Selection.php
@@ -64,7 +64,13 @@ final class Selection
     {
         $rng ??= static fn (): float => mt_rand() / mt_getrandmax();
         $count = count($candidates);
-        return $count === 0 ? null : $candidates[(int) floor($rng() * $count)];
+        if ($count === 0) {
+            return null;
+        }
+        // Clamp: the default rng can return exactly 1.0 (mt_rand() == mt_getrandmax()),
+        // which would otherwise index one past the end.
+        $index = min((int) floor($rng() * $count), $count - 1);
+        return $candidates[$index];
     }
 
     /** @return array<string,callable> name → strategy */

--- a/tests/Db/DbTestCase.php
+++ b/tests/Db/DbTestCase.php
@@ -21,7 +21,11 @@ abstract class DbTestCase extends TestCase
 
     protected function setUp(): void
     {
-        if (getenv('DATABASE_URL') === false) {
+        // Treat an empty/whitespace value as unset too: Config maps '' back to the
+        // DEFAULT (dev) DB URL, so running here would risk writing to the dev
+        // schema instead of the throwaway addiapp_test one.
+        $dbUrl = getenv('DATABASE_URL');
+        if ($dbUrl === false || trim($dbUrl) === '') {
             self::markTestSkipped('DATABASE_URL not set — DB tests need a migrated addiapp_test schema.');
         }
         $this->pdo = Db::pdo();

--- a/tests/Unit/SelectionTest.php
+++ b/tests/Unit/SelectionTest.php
@@ -14,7 +14,11 @@ use PHPUnit\Framework\TestCase;
  */
 final class SelectionTest extends TestCase
 {
-    /** Oldest -> youngest by createdAt; ids intentionally NOT in age order. */
+    /**
+     * Deliberately NOT in age order (youngest is listed first) and the ids do NOT
+     * correlate with age — so a passing test can't be quietly relying on input
+     * order. By createdAt the oldest is id 10, then 20, then 30 (the youngest).
+     */
     private const CANDIDATES = [
         ['id' => 30, 'createdAt' => '2026-01-03 10:00:00'], // youngest
         ['id' => 10, 'createdAt' => '2026-01-01 10:00:00'], // oldest
@@ -83,6 +87,14 @@ final class SelectionTest extends TestCase
         // After no sorting, uniformRandom indexes the list as-is: rng*count floored.
         self::assertSame(30, Selection::uniformRandom(self::CANDIDATES, static fn (): float => 0.0)['id']);
         self::assertSame(20, Selection::uniformRandom(self::CANDIDATES, static fn (): float => 0.999)['id']);
+    }
+
+    public function testUniformRandomClampsRngEqualToOne(): void
+    {
+        // The default rng (mt_rand()/mt_getrandmax()) can return exactly 1.0, which
+        // would index one past the end — the index must clamp to the last element.
+        $picked = Selection::uniformRandom(self::CANDIDATES, static fn (): float => 1.0);
+        self::assertSame(20, $picked['id']); // last element of the (unsorted) list
     }
 
     public function testStrategiesMapExposesAllThree(): void


### PR DESCRIPTION
## Summary
Fixes the three Copilot review comments on promotion PR #130 (ships #124): skip DB tests on empty DATABASE_URL (avoid the dev-DB fallback), clamp Selection::uniformRandom against rng()==1.0 (+ regression test), and correct a misleading test docblock. Suite green (35 tests, 54 assertions).

## Changes
- #131 - TECH-1 promotion review fixes (Copilot on PR #130)

Closes #131