### PR TITLE
Close #133 - Visual refresh v2 (B) — Batch 1: retrofit Play-loop screens + Mascot to tokens

### DIFF
--- a/.changes/unreleased/133-visual-refresh-v2-b-batch-1.md
+++ b/.changes/unreleased/133-visual-refresh-v2-b-batch-1.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Changed -->
+- Visual refresh v2 (B) — Batch 1: retrofit Play-loop screens + Mascot to tokens ([#133](https://github.com/neturely/addiapp/issues/133))

--- a/client/src/components/Completion.tsx
+++ b/client/src/components/Completion.tsx
@@ -2,16 +2,16 @@ import { Link } from 'react-router-dom'
 import { Mascot } from './Mascot'
 import type { WinSize } from '@/lib/tasks'
 
-/** A few static confetti-dot accents — moderate ceremony, no animation library. */
+/** Confetti-dot accents — staggered CSS keyframe (pop/drift/fade), no library. */
 const CONFETTI = [
-  { color: '#D85A30', top: '14%', left: '16%', pulse: true },
-  { color: '#2FA39B', top: '22%', left: '80%', pulse: false },
-  { color: '#F5A623', top: '38%', left: '10%', pulse: false },
-  { color: '#8B5CF6', top: '12%', left: '58%', pulse: true },
-  { color: '#2FA39B', top: '30%', left: '38%', pulse: false },
-  { color: '#F5A623', top: '18%', left: '34%', pulse: true },
-  { color: '#8B5CF6', top: '40%', left: '72%', pulse: false },
-  { color: '#D85A30', top: '48%', left: '24%', pulse: false },
+  { color: 'var(--color-primary)', top: '14%', left: '16%', delay: '0s' },
+  { color: 'var(--color-success)', top: '22%', left: '80%', delay: '0.5s' },
+  { color: 'var(--color-warning)', top: '38%', left: '10%', delay: '0.9s' },
+  { color: 'var(--color-accent)', top: '12%', left: '58%', delay: '0.2s' },
+  { color: 'var(--color-success)', top: '30%', left: '38%', delay: '1.2s' },
+  { color: 'var(--color-warning)', top: '18%', left: '34%', delay: '0.7s' },
+  { color: 'var(--color-accent)', top: '40%', left: '72%', delay: '1.5s' },
+  { color: 'var(--color-primary)', top: '48%', left: '24%', delay: '0.35s' },
 ]
 
 type CompletionProps = {
@@ -45,26 +45,26 @@ export function Completion({ title, totalPoints, multiplier, size, minutes }: Co
         <span
           key={i}
           aria-hidden
-          className={`absolute h-2.5 w-2.5 rounded-full ${c.pulse ? 'animate-pulse' : ''}`}
-          style={{ backgroundColor: c.color, top: c.top, left: c.left }}
+          className="animate-confetti absolute h-2.5 w-2.5 rounded-full"
+          style={{ backgroundColor: c.color, top: c.top, left: c.left, animationDelay: c.delay }}
         />
       ))}
 
       <Mascot mood="happy" />
       <h1 className="text-3xl font-bold text-gray-800">Nice work!</h1>
-      <p className="text-gray-500">{title}</p>
+      <p className="text-muted">{title}</p>
 
       {totalPoints != null && (
-        <div className="text-6xl font-extrabold tabular-nums text-[#D85A30]">+{totalPoints}</div>
+        <div className="text-6xl font-extrabold tabular-nums text-primary">+{totalPoints}</div>
       )}
 
       {multiplier != null && multiplier > 1 && (
-        <p className="text-sm text-gray-400">Current daily bonus: {+multiplier.toFixed(2)}x</p>
+        <p className="text-sm text-muted">Current daily bonus: {+multiplier.toFixed(2)}x</p>
       )}
 
       <Link
         to={keepGoingHref}
-        className="mt-2 rounded-xl bg-[#D85A30] px-8 py-3 text-lg font-semibold text-white transition hover:bg-[#c24d27]"
+        className="mt-2 rounded-xl bg-primary px-8 py-3 text-lg font-semibold text-white transition hover:opacity-90"
       >
         Keep going
       </Link>

--- a/client/src/components/EmptyState.tsx
+++ b/client/src/components/EmptyState.tsx
@@ -15,7 +15,7 @@ export function EmptyState({ filtered = false }: { filtered?: boolean }) {
       <Mascot mood="sleepy" />
       <div className="space-y-1">
         <h1 className="text-2xl font-bold text-gray-800">Nothing here right now</h1>
-        <p className="text-gray-500">
+        <p className="text-muted">
           {filtered
             ? 'No task matches that pick. Try a different kind of win or more time.'
             : 'Your backlog is empty. Add a task to get the ball rolling.'}
@@ -24,13 +24,13 @@ export function EmptyState({ filtered = false }: { filtered?: boolean }) {
       <div className="flex flex-col gap-3">
         <Link
           to={filtered ? '/play' : '/tasks/new'}
-          className="rounded-lg bg-[#D85A30] px-6 py-3 font-semibold text-white transition hover:bg-[#c24d27]"
+          className="rounded-lg bg-primary px-6 py-3 font-semibold text-white transition hover:opacity-90"
         >
           {filtered ? 'Pick a different win' : 'Add a task'}
         </Link>
         <Link
           to={filtered ? '/tasks/new' : '/play'}
-          className="text-sm text-gray-500 underline hover:text-gray-700"
+          className="text-sm text-muted underline hover:text-gray-700"
         >
           {filtered ? 'Add a task' : 'Choose a win'}
         </Link>

--- a/client/src/components/Mascot.tsx
+++ b/client/src/components/Mascot.tsx
@@ -17,7 +17,7 @@ export function Mascot({ mood = 'happy', className = '' }: { mood?: Mood; classN
       height="120"
     >
       {/* body */}
-      <ellipse cx="60" cy="66" rx="42" ry="40" fill="#D85A30" />
+      <ellipse cx="60" cy="66" rx="42" ry="40" fill="var(--color-primary)" />
       <ellipse cx="60" cy="72" rx="30" ry="26" fill="#F3B598" />
       {/* eyes */}
       {mood === 'sleepy' ? (
@@ -46,8 +46,8 @@ export function Mascot({ mood = 'happy', className = '' }: { mood?: Mood; classN
         />
       )}
       {/* little antenna */}
-      <line x1="60" y1="26" x2="60" y2="14" stroke="#D85A30" strokeWidth="3" strokeLinecap="round" />
-      <circle cx="60" cy="11" r="5" fill="#F5A623" />
+      <line x1="60" y1="26" x2="60" y2="14" stroke="var(--color-primary)" strokeWidth="3" strokeLinecap="round" />
+      <circle cx="60" cy="11" r="5" fill="var(--color-warning)" />
     </svg>
   )
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -17,9 +17,34 @@
   --color-accent: #6e3fd6;
   --color-accent-tint: #f1ebfd;
   --color-warning: #d98a00;
+  --color-warning-tint: #fbeed3;
   --color-muted: #5b6270;
   --color-page: #f6f1ea;
   --color-surface: #ffffff;
+
+  /* Completion-screen confetti (#94 B1): pop-in, drift down, fade. */
+  --animate-confetti: confetti 2.4s ease-in-out infinite;
+}
+
+@keyframes confetti {
+  0% {
+    transform: translateY(-8px) scale(0.4);
+    opacity: 0;
+  }
+  25% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(18px) scale(1);
+    opacity: 0;
+  }
+}
+
+/* Respect reduced-motion: show the dots statically rather than animating. */
+@media (prefers-reduced-motion: reduce) {
+  .animate-confetti {
+    animation: none;
+  }
 }
 
 /*

--- a/client/src/pages/Choice.tsx
+++ b/client/src/pages/Choice.tsx
@@ -29,11 +29,33 @@ export function Choice() {
 
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-8 p-8 text-center">
-      <Mascot mood="thinking" />
       <h1 className="text-2xl font-bold text-gray-800">What kind of win do you want?</h1>
 
+      {/* The mascot presents two equal paths — small (left) / big (right). */}
+      <div className="flex w-full max-w-2xl items-stretch justify-center gap-3 sm:gap-5">
+        <button
+          type="button"
+          onClick={() => go('small')}
+          className="flex flex-1 flex-col justify-center rounded-2xl bg-surface p-5 transition hover:bg-success-tint"
+        >
+          <div className="text-lg font-bold text-success">Something small</div>
+          <div className="mt-1 text-sm text-muted">A quick, low-effort win</div>
+        </button>
+
+        <Mascot mood="thinking" className="h-20 w-20 shrink-0 self-center sm:h-24 sm:w-24" />
+
+        <button
+          type="button"
+          onClick={() => go('big')}
+          className="flex flex-1 flex-col justify-center rounded-2xl bg-surface p-5 transition hover:bg-primary-tint"
+        >
+          <div className="text-lg font-bold text-primary">Something big</div>
+          <div className="mt-1 text-sm text-muted">Real progress worth more points</div>
+        </button>
+      </div>
+
       <div className="w-full max-w-md">
-        <p className="mb-2 text-sm font-medium text-gray-500">How much time do you have?</p>
+        <p className="mb-2 text-sm font-medium text-muted">How much time do you have?</p>
         <div className="flex flex-wrap justify-center gap-2">
           {TIME_OPTIONS.map((opt) => {
             const active = minutes === opt.minutes
@@ -43,9 +65,7 @@ export function Choice() {
                 type="button"
                 onClick={() => setMinutes(opt.minutes)}
                 className={`rounded-full px-4 py-1.5 text-sm font-medium transition ${
-                  active
-                    ? 'bg-gray-800 text-white'
-                    : 'border border-gray-300 text-gray-600 hover:bg-gray-50'
+                  active ? 'bg-primary text-white' : 'bg-surface text-muted hover:bg-primary-tint'
                 }`}
               >
                 {opt.label}
@@ -53,25 +73,6 @@ export function Choice() {
             )
           })}
         </div>
-      </div>
-
-      <div className="grid w-full max-w-md gap-4 sm:grid-cols-2">
-        <button
-          type="button"
-          onClick={() => go('small')}
-          className="rounded-2xl border-2 border-[#2FA39B] bg-[#2FA39B]/10 p-6 text-left transition hover:bg-[#2FA39B]/20"
-        >
-          <div className="text-lg font-bold text-[#1f746e]">Something small</div>
-          <div className="text-sm text-gray-600">A quick, low-effort win</div>
-        </button>
-        <button
-          type="button"
-          onClick={() => go('big')}
-          className="rounded-2xl border-2 border-[#D85A30] bg-[#D85A30]/10 p-6 text-left transition hover:bg-[#D85A30]/20"
-        >
-          <div className="text-lg font-bold text-[#a8431f]">Something big</div>
-          <div className="text-sm text-gray-600">Real progress worth more points</div>
-        </button>
       </div>
     </main>
   )

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
+import { Play } from 'lucide-react'
 import { Mascot } from '@/components/Mascot'
 import { fetchTasks, type Task } from '@/lib/tasks'
 
@@ -41,15 +42,16 @@ export function Home() {
       {resume && (
         <Link
           to={`/play/progress/${resume.id}`}
-          className="flex w-full max-w-sm items-center justify-center gap-2 rounded-xl border-2 border-[#F5A623] bg-[#F5A623]/10 px-6 py-3 font-semibold text-[#a06d00] transition hover:bg-[#F5A623]/20"
+          className="flex w-full max-w-sm items-center justify-center gap-2 rounded-xl bg-accent-tint px-6 py-3 font-semibold text-accent transition hover:opacity-90"
         >
-          ▸ Resume: <span className="max-w-[16rem] truncate">{resume.title}</span>
+          <Play className="h-4 w-4 shrink-0" fill="currentColor" strokeWidth={0} />
+          Resume: <span className="max-w-[16rem] truncate">{resume.title}</span>
         </Link>
       )}
 
       <Link
         to="/play"
-        className="mt-2 rounded-xl bg-[#D85A30] px-10 py-3 text-lg font-semibold text-white transition hover:bg-[#c24d27]"
+        className="mt-2 rounded-xl bg-primary px-10 py-3 text-lg font-semibold text-white transition hover:opacity-90"
       >
         Let&apos;s go
       </Link>

--- a/client/src/pages/InProgress.tsx
+++ b/client/src/pages/InProgress.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
+import { Zap } from 'lucide-react'
 import { Mascot } from '@/components/Mascot'
 import { Completion } from '@/components/Completion'
 import { completeTask, getTask, parseMinutes, type AwardResult, type Task } from '@/lib/tasks'
@@ -108,15 +109,15 @@ export function InProgress() {
   }, [task])
 
   if (loading) {
-    return <main className="flex min-h-screen items-center justify-center text-gray-500">Loading…</main>
+    return <main className="flex min-h-screen items-center justify-center text-muted">Loading…</main>
   }
 
   if (error && !task) {
     return (
       <main className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center">
         <Mascot mood="sleepy" />
-        <p className="text-gray-600">{error}</p>
-        <Link to="/play" className="text-sm text-gray-500 underline hover:text-gray-700">
+        <p className="text-gray-700">{error}</p>
+        <Link to="/play" className="text-sm text-muted underline hover:text-gray-700">
           Back to Play
         </Link>
       </main>
@@ -147,9 +148,9 @@ export function InProgress() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8 text-center">
       <Mascot mood="happy" />
-      <p className="text-sm font-semibold uppercase tracking-wide text-gray-400">Working on it</p>
+      <p className="text-sm font-semibold uppercase tracking-wide text-muted">Working on it</p>
 
-      <div className="w-full max-w-md rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+      <div className="w-full max-w-md rounded-2xl bg-surface p-6">
         <h1 className="text-xl font-bold text-gray-800">{task.title}</h1>
 
         <div className="mt-4 font-mono text-5xl font-bold tabular-nums text-gray-900">
@@ -160,12 +161,12 @@ export function InProgress() {
           <div className="h-3 w-full overflow-hidden rounded-full bg-gray-100">
             <div
               className={`h-full rounded-full transition-[width] duration-500 ${
-                inBonus ? 'bg-[#2FA39B]' : 'bg-[#D85A30]'
+                inBonus ? 'bg-success' : 'bg-warning'
               }`}
               style={{ width: `${meterFrac * 100}%` }}
             />
           </div>
-          <div className="mt-1 text-xs text-gray-500">
+          <div className="mt-1 text-xs text-muted">
             {elapsedMin} / {task.estimatedMinutes} min
           </div>
         </div>
@@ -173,14 +174,15 @@ export function InProgress() {
         <p className="mt-4 text-sm font-medium text-gray-600">
           {inBonus ? (
             <>
-              ⚡ Finish within{' '}
-              <span className="font-bold text-[#1f746e]">{formatClock(estimateSec - elapsed)}</span>{' '}
+              <Zap className="mb-0.5 inline h-4 w-4 text-warning" fill="currentColor" strokeWidth={0} />{' '}
+              Finish within{' '}
+              <span className="font-bold text-success">{formatClock(estimateSec - elapsed)}</span>{' '}
               for a speed bonus
             </>
           ) : (
             <>
               Past the estimate — no speed bonus now
-              {basePoints != null ? `, but it's still worth ${basePoints} pts` : ''}. Finish strong 💪
+              {basePoints != null ? `, but it's still worth ${basePoints} pts` : ''}. Finish strong.
             </>
           )}
         </p>
@@ -191,13 +193,13 @@ export function InProgress() {
           type="button"
           onClick={() => void onComplete()}
           disabled={completing}
-          className="mt-5 w-full rounded-lg bg-[#D85A30] py-3 font-semibold text-white transition hover:bg-[#c24d27] disabled:bg-gray-400"
+          className="mt-5 w-full rounded-lg bg-primary py-3 font-semibold text-white transition hover:opacity-90 disabled:bg-gray-400"
         >
           {completing ? 'Completing…' : 'Complete'}
         </button>
       </div>
 
-      <p className="text-sm text-gray-400">
+      <p className="text-sm text-muted">
         You can leave any time — this task stays in progress until you complete it.
       </p>
     </main>

--- a/client/src/pages/TaskPresented.tsx
+++ b/client/src/pages/TaskPresented.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import { Shuffle, SlidersHorizontal } from 'lucide-react'
 import { Mascot } from '@/components/Mascot'
 import { EmptyState } from '@/components/EmptyState'
 import {
@@ -13,9 +14,9 @@ import {
 import { fetchPoints, type PointsStats } from '@/lib/points'
 
 const COMPLEXITY_TAG: Record<TaskComplexity, { label: string; className: string }> = {
-  low: { label: 'Low effort', className: 'bg-[#2FA39B]/15 text-[#1f746e]' },
-  medium: { label: 'Medium', className: 'bg-[#F5A623]/15 text-[#a06d00]' },
-  high: { label: 'Big effort', className: 'bg-[#D85A30]/15 text-[#a8431f]' },
+  low: { label: 'Low effort', className: 'bg-success-tint text-success' },
+  medium: { label: 'Medium', className: 'bg-warning-tint text-[#8a5a00]' },
+  high: { label: 'Big effort', className: 'bg-primary-tint text-primary' },
 }
 
 function formatMinutes(m: number): string {
@@ -92,7 +93,7 @@ export function TaskPresented() {
   }
 
   if (loading) {
-    return <main className="flex min-h-screen items-center justify-center text-gray-500">Finding you a task…</main>
+    return <main className="flex min-h-screen items-center justify-center text-muted">Finding you a task…</main>
   }
 
   if (!task) {
@@ -107,17 +108,17 @@ export function TaskPresented() {
     <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8 text-center">
       <Mascot mood="happy" />
 
-      <div className="w-full max-w-md rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+      <div className="w-full max-w-md rounded-2xl bg-surface p-6">
         <span className={`inline-block rounded-full px-3 py-1 text-xs font-semibold ${tag.className}`}>
           {tag.label}
         </span>
         <h1 className="mt-3 text-2xl font-bold text-gray-800">{task.title}</h1>
-        <p className="mt-1 text-gray-500">~{formatMinutes(task.estimatedMinutes)}</p>
+        <p className="mt-1 text-muted">~{formatMinutes(task.estimatedMinutes)}</p>
 
         {basePoints != null && (
-          <div className="mt-4 rounded-xl bg-gray-50 p-3">
-            <div className="text-lg font-bold text-[#a8431f]">≈ {basePoints} pts</div>
-            <div className="text-xs text-gray-500">
+          <div className="mt-4 rounded-xl bg-primary-tint p-3">
+            <div className="text-lg font-bold text-primary">≈ {basePoints} pts</div>
+            <div className="text-xs text-muted">
               + speed bonus if you beat the estimate
               {multiplier && multiplier > 1 ? ` · ×${multiplier.toFixed(2)} today` : ''}
             </div>
@@ -130,22 +131,29 @@ export function TaskPresented() {
           type="button"
           onClick={onStart}
           disabled={starting}
-          className="mt-5 w-full rounded-lg bg-[#D85A30] py-3 font-semibold text-white transition hover:bg-[#c24d27] disabled:bg-gray-400"
+          className="mt-5 w-full rounded-lg bg-primary py-3 font-semibold text-white transition hover:opacity-90 disabled:bg-gray-400"
         >
           {starting ? 'Starting…' : 'Start'}
         </button>
-        <button
-          type="button"
-          onClick={() => void roll(task.id)}
-          className="mt-2 w-full rounded-lg py-2 text-sm text-gray-500 underline hover:text-gray-700"
-        >
-          Give me something else
-        </button>
-      </div>
 
-      <Link to="/play" className="text-sm text-gray-500 underline hover:text-gray-700">
-        Change my pick
-      </Link>
+        <div className="mt-3 flex flex-col gap-1">
+          <button
+            type="button"
+            onClick={() => void roll(task.id)}
+            className="inline-flex w-full items-center justify-center gap-2 rounded-lg py-2 text-sm font-medium text-muted transition hover:bg-primary-tint hover:text-primary"
+          >
+            <Shuffle className="h-4 w-4" />
+            Give me something else
+          </button>
+          <Link
+            to="/play"
+            className="inline-flex w-full items-center justify-center gap-2 rounded-lg py-2 text-sm font-medium text-muted transition hover:bg-primary-tint hover:text-primary"
+          >
+            <SlidersHorizontal className="h-4 w-4" />
+            Change my pick
+          </Link>
+        </div>
+      </div>
     </main>
   )
 }


### PR DESCRIPTION
## Summary
Batch 1 of the #94 retrofit — Play loop + Mascot to v2 tokens. Retires #D85A30 across the play flow (Mascot, Home, Choice, TaskPresented, InProgress, Completion, EmptyState); flat token surfaces, no borders/shadows. Highlights: Choice rebuilt mascot-flanked (two equal white cards), TaskPresented secondary actions → icon+label ghost buttons, InProgress ⚡→Lucide Zap, Completion confetti animated (reduced-motion aware). Defines --color-warning-tint (#FBEED3). All WCAG AA combos verified by calculation; every play screen verified live via headless Chrome.

## Changes
- chore: init branch for #133
- #133 - Visual refresh v2 (B) Batch 1: retrofit Play-loop screens + Mascot

Closes #133