### PR TITLE
Close #137 - Visual refresh v2 (B) — Batch 2: retrofit Dashboard + PointsCard to tokens

### DIFF
--- a/.changes/unreleased/137-visual-refresh-v2-b-batch-2.md
+++ b/.changes/unreleased/137-visual-refresh-v2-b-batch-2.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Changed -->
+- Visual refresh v2 (B) — Batch 2: retrofit Dashboard + PointsCard to tokens ([#137](https://github.com/neturely/addiapp/issues/137))

--- a/client/src/components/PointsCard.tsx
+++ b/client/src/components/PointsCard.tsx
@@ -37,21 +37,21 @@ export function PointsCard({ refreshSignal = 0 }: { refreshSignal?: number }) {
   return (
     <Link
       to="/stats"
-      className="mb-6 flex flex-wrap items-center justify-between gap-4 rounded-2xl bg-gradient-to-r from-[#D85A30] to-[#e07a52] p-5 text-white transition hover:brightness-105"
+      className="mb-6 flex flex-wrap items-center justify-between gap-4 rounded-2xl bg-primary p-5 text-white transition hover:opacity-90"
     >
       <div>
-        <div className="text-xs font-medium uppercase tracking-wide text-white/80">Total points</div>
+        <div className="text-xs font-medium uppercase tracking-wide text-white">Total points</div>
         <div className="text-4xl font-extrabold tabular-nums">{total.toLocaleString()}</div>
       </div>
       <div className="flex gap-6 text-right">
         <div>
-          <div className="text-xs font-medium uppercase tracking-wide text-white/80">Daily bonus</div>
+          <div className="text-xs font-medium uppercase tracking-wide text-white">Daily bonus</div>
           <div className="text-2xl font-bold tabular-nums">×{+multiplier.toFixed(2)}</div>
         </div>
         <div>
-          <div className="text-xs font-medium uppercase tracking-wide text-white/80">Today</div>
+          <div className="text-xs font-medium uppercase tracking-wide text-white">Today</div>
           <div className="text-2xl font-bold tabular-nums">{pointsToday}</div>
-          <div className="text-xs text-white/80">
+          <div className="text-xs text-white">
             {tasksToday} {tasksToday === 1 ? 'task' : 'tasks'}
           </div>
         </div>

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -21,15 +21,15 @@ const FILTERS: { key: Filter; label: string }[] = [
 ]
 
 const COMPLEXITY_TAG: Record<TaskComplexity, { label: string; className: string }> = {
-  low: { label: 'Low', className: 'bg-[#2FA39B]/15 text-[#1f746e]' },
-  medium: { label: 'Medium', className: 'bg-[#F5A623]/15 text-[#a06d00]' },
-  high: { label: 'High', className: 'bg-[#D85A30]/15 text-[#a8431f]' },
+  low: { label: 'Low', className: 'bg-success-tint text-success' },
+  medium: { label: 'Medium', className: 'bg-warning-tint text-[#8a5a00]' },
+  high: { label: 'High', className: 'bg-primary-tint text-primary' },
 }
 
 const STATUS_BADGE: Record<TaskStatus, { label: string; className: string }> = {
-  backlog: { label: 'Backlog', className: 'bg-gray-100 text-gray-600' },
-  in_progress: { label: 'In progress', className: 'bg-[#F5A623]/15 text-[#a06d00]' },
-  done: { label: 'Done', className: 'bg-[#2FA39B]/15 text-[#1f746e]' },
+  backlog: { label: 'Backlog', className: 'bg-gray-100 text-muted' },
+  in_progress: { label: 'In progress', className: 'bg-warning-tint text-[#8a5a00]' },
+  done: { label: 'Done', className: 'bg-success-tint text-success' },
 }
 
 const MAX_TITLE = 255
@@ -199,10 +199,10 @@ export function Dashboard() {
               key={f.key}
               onClick={() => setFilter(f.key)}
               className={`rounded-full px-3 py-1 text-sm font-medium transition ${
-                active ? 'bg-gray-800 text-white' : 'border border-gray-300 text-gray-600 hover:bg-gray-50'
+                active ? 'bg-primary text-white' : 'bg-surface text-muted hover:bg-primary-tint'
               }`}
             >
-              {f.label} <span className={active ? 'text-gray-300' : 'text-gray-400'}>{count}</span>
+              {f.label} <span className={active ? 'text-white' : 'text-muted'}>{count}</span>
             </button>
           )
         })}
@@ -211,20 +211,20 @@ export function Dashboard() {
       {error && <p className="mb-3 text-sm text-red-600">{error}</p>}
 
       {loading ? (
-        <p className="p-8 text-center text-gray-500">Loading…</p>
+        <p className="p-8 text-center text-muted">Loading…</p>
       ) : visible.length === 0 ? (
-        <div className="rounded-2xl border border-dashed border-gray-200 p-10 text-center">
-          <p className="text-gray-500">
+        <div className="rounded-2xl bg-surface p-10 text-center">
+          <p className="text-muted">
             {tasks.length === 0 ? 'No tasks yet.' : `No ${FILTERS.find((f) => f.key === filter)?.label.toLowerCase()} tasks.`}
           </p>
-          <Link to="/tasks/new" className="mt-2 inline-block text-sm text-[#a8431f] underline">
+          <Link to="/tasks/new" className="mt-2 inline-block text-sm text-primary underline">
             Add a task
           </Link>
         </div>
       ) : (
-        <div className="overflow-x-auto rounded-2xl border border-gray-200">
+        <div className="overflow-x-auto rounded-2xl bg-surface">
           <table className="w-full min-w-[640px] text-left text-sm">
-            <thead className="border-b border-gray-200 bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
+            <thead className="bg-gray-50 text-xs uppercase tracking-wide text-muted">
               <tr>
                 <th className="px-4 py-3 font-medium">Title</th>
                 <th className="px-4 py-3 font-medium">Effort</th>
@@ -233,19 +233,19 @@ export function Dashboard() {
                 <th className="px-4 py-3 text-right font-medium">Actions</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-100">
+            <tbody>
               {visible.map((task) => {
                 const editing = editingId === task.id && editValues
                 if (editing) {
                   return (
-                    <tr key={task.id} className="bg-[#D85A30]/5 align-top">
+                    <tr key={task.id} className="bg-primary-tint align-top">
                       <td className="px-4 py-2">
                         <input
                           autoFocus
                           value={editValues.title}
                           maxLength={MAX_TITLE}
                           onChange={(e) => setEditValues({ ...editValues, title: e.target.value })}
-                          className="w-full rounded border border-gray-300 p-1.5"
+                          className="w-full rounded bg-gray-100 p-1.5"
                         />
                         {rowError && <p className="mt-1 text-xs text-red-600">{rowError}</p>}
                       </td>
@@ -255,7 +255,7 @@ export function Dashboard() {
                           onChange={(e) =>
                             setEditValues({ ...editValues, complexity: e.target.value as TaskComplexity })
                           }
-                          className="rounded border border-gray-300 p-1.5"
+                          className="rounded bg-gray-100 p-1.5"
                         >
                           <option value="low">Low</option>
                           <option value="medium">Medium</option>
@@ -271,7 +271,7 @@ export function Dashboard() {
                           onChange={(e) =>
                             setEditValues({ ...editValues, estimatedMinutes: e.target.value })
                           }
-                          className="w-20 rounded border border-gray-300 p-1.5"
+                          className="w-20 rounded bg-gray-100 p-1.5"
                         />
                       </td>
                       <td className="px-4 py-2">
@@ -280,7 +280,7 @@ export function Dashboard() {
                           onChange={(e) =>
                             setEditValues({ ...editValues, status: e.target.value as TaskStatus })
                           }
-                          className="rounded border border-gray-300 p-1.5"
+                          className="rounded bg-gray-100 p-1.5"
                         >
                           <option value="backlog">Backlog</option>
                           <option value="in_progress">In progress</option>
@@ -291,7 +291,7 @@ export function Dashboard() {
                         <button
                           onClick={() => void saveEdit(task)}
                           disabled={savingId === task.id}
-                          className="rounded bg-[#D85A30] px-3 py-1 text-xs font-semibold text-white hover:bg-[#c24d27] disabled:bg-gray-400"
+                          className="rounded bg-primary px-3 py-1 text-xs font-semibold text-white transition hover:opacity-90 disabled:bg-gray-400"
                         >
                           {savingId === task.id ? 'Saving…' : 'Save'}
                         </button>
@@ -300,7 +300,7 @@ export function Dashboard() {
                             setEditingId(null)
                             setRowError(null)
                           }}
-                          className="ml-2 text-xs text-gray-500 underline hover:text-gray-700"
+                          className="ml-2 text-xs text-muted underline hover:text-gray-700"
                         >
                           Cancel
                         </button>
@@ -312,7 +312,7 @@ export function Dashboard() {
                 const tag = COMPLEXITY_TAG[task.complexity]
                 const badge = STATUS_BADGE[task.status]
                 return (
-                  <tr key={task.id} className="hover:bg-gray-50">
+                  <tr key={task.id} className="even:bg-gray-50 hover:bg-primary-tint">
                     <td
                       onClick={() => startEdit(task)}
                       className="cursor-pointer px-4 py-3 font-medium text-gray-800"
@@ -325,7 +325,7 @@ export function Dashboard() {
                         {tag.label}
                       </span>
                     </td>
-                    <td onClick={() => startEdit(task)} className="cursor-pointer px-4 py-3 text-gray-500">
+                    <td onClick={() => startEdit(task)} className="cursor-pointer px-4 py-3 text-muted">
                       {task.estimatedMinutes}m
                     </td>
                     <td onClick={() => startEdit(task)} className="cursor-pointer px-4 py-3">
@@ -337,7 +337,7 @@ export function Dashboard() {
                       {task.status === 'backlog' && (
                         <button
                           onClick={() => void onStart(task)}
-                          className="text-xs font-semibold text-[#a8431f] hover:underline"
+                          className="text-xs font-semibold text-primary hover:underline"
                         >
                           Start
                         </button>
@@ -345,20 +345,20 @@ export function Dashboard() {
                       {task.status === 'in_progress' && (
                         <Link
                           to={`/play/progress/${task.id}`}
-                          className="text-xs font-semibold text-[#a06d00] hover:underline"
+                          className="text-xs font-semibold text-[#8a5a00] hover:underline"
                         >
                           Resume
                         </Link>
                       )}
                       <Link
                         to={`/tasks/${task.id}/edit`}
-                        className="ml-3 text-xs text-gray-500 hover:underline"
+                        className="ml-3 text-xs text-muted hover:underline"
                       >
                         Edit
                       </Link>
                       <button
                         onClick={() => onDelete(task)}
-                        className="ml-3 text-xs text-gray-500 hover:text-red-600 hover:underline"
+                        className="ml-3 text-xs text-muted hover:text-red-600 hover:underline"
                       >
                         Delete
                       </button>
@@ -372,11 +372,11 @@ export function Dashboard() {
       )}
 
       {pendingTask && (
-        <div className="fixed bottom-6 left-1/2 flex -translate-x-1/2 items-center gap-4 rounded-lg bg-gray-900 px-4 py-3 text-sm text-white shadow-lg">
+        <div className="fixed bottom-6 left-1/2 flex -translate-x-1/2 items-center gap-4 rounded-lg bg-gray-900 px-4 py-3 text-sm text-white">
           <span>
             Deleted “{pendingTask.title.length > 32 ? pendingTask.title.slice(0, 32) + '…' : pendingTask.title}”
           </span>
-          <button onClick={undoDelete} className="font-semibold text-[#F5A623] hover:underline">
+          <button onClick={undoDelete} className="font-semibold text-warning hover:underline">
             Undo
           </button>
         </div>


### PR DESCRIPTION
## Summary
Batch 2 of the #94 retrofit — Dashboard + PointsCard to v2 tokens. PointsCard gradient → flat solid primary; effort/status badges → token tints; all borders/shadows stripped (table → flat surface + zebra rows, flat undo toast, filled inline-edit inputs); and the #133 item-4 fix: editable rows now hover to a visible primary-tint. All WCAG AA combos verified by calculation; live headless-Chrome verified across normal / hover / inline-edit / undo-toast states.

## Changes
- chore: init branch for #137
- #137 - Visual refresh v2 (B) Batch 2: retrofit Dashboard + PointsCard to tokens

Closes #137