### PR TITLE
Close #139 - Visual refresh v2 (B) — Batch 3: retrofit Forms + Stats to tokens

### DIFF
--- a/.changes/unreleased/139-visual-refresh-v2-b-batch-3.md
+++ b/.changes/unreleased/139-visual-refresh-v2-b-batch-3.md
@@ -1,0 +1,2 @@
+<!-- okffs:type=Changed -->
+- Visual refresh v2 (B) — Batch 3: retrofit Forms + Stats to tokens ([#139](https://github.com/neturely/addiapp/issues/139))

--- a/client/src/components/TaskForm.tsx
+++ b/client/src/components/TaskForm.tsx
@@ -84,7 +84,7 @@ export function TaskForm({ initial, submitLabel, submittingLabel, onSubmit }: Ta
           maxLength={MAX_TITLE}
           placeholder="e.g. Draft the sprint notes"
           onChange={(e) => setTitle(e.target.value)}
-          className="w-full rounded-lg border border-gray-300 p-2.5 focus:border-[#D85A30] focus:outline-none"
+          className="w-full rounded-lg bg-gray-100 p-2.5 focus:ring-2 focus:ring-primary focus:outline-none"
         />
       </div>
 
@@ -98,12 +98,14 @@ export function TaskForm({ initial, submitLabel, submittingLabel, onSubmit }: Ta
                 key={c}
                 type="button"
                 onClick={() => setComplexity(c)}
-                className={`rounded-lg border-2 py-2 text-center transition ${
-                  active ? 'border-[#D85A30] bg-[#D85A30]/10' : 'border-gray-200 hover:border-gray-300'
+                className={`rounded-lg py-2 text-center transition ${
+                  active ? 'bg-primary-tint' : 'bg-gray-100 hover:bg-gray-200'
                 }`}
               >
-                <div className="text-sm font-semibold text-gray-800">{COMPLEXITY_LABEL[c]}</div>
-                <div className="text-xs text-gray-500">{basePoints[c]} pts</div>
+                <div className={`text-sm font-semibold ${active ? 'text-primary' : 'text-gray-800'}`}>
+                  {COMPLEXITY_LABEL[c]}
+                </div>
+                <div className="text-xs text-muted">{basePoints[c]} pts</div>
               </button>
             )
           })}
@@ -123,9 +125,9 @@ export function TaskForm({ initial, submitLabel, submittingLabel, onSubmit }: Ta
           value={minutes}
           placeholder="e.g. 25"
           onChange={(e) => setMinutes(e.target.value)}
-          className="w-full rounded-lg border border-gray-300 p-2.5 focus:border-[#D85A30] focus:outline-none"
+          className="w-full rounded-lg bg-gray-100 p-2.5 focus:ring-2 focus:ring-primary focus:outline-none"
         />
-        <p className="mt-1 text-xs text-gray-400">Beat your estimate to earn a speed bonus.</p>
+        <p className="mt-1 text-xs text-muted">Beat your estimate to earn a speed bonus.</p>
       </div>
 
       {error && <p className="text-sm text-red-600">{error}</p>}
@@ -133,7 +135,7 @@ export function TaskForm({ initial, submitLabel, submittingLabel, onSubmit }: Ta
       <button
         type="submit"
         disabled={submitting}
-        className="w-full rounded-lg bg-[#D85A30] py-3 font-semibold text-white transition hover:bg-[#c24d27] disabled:bg-gray-400"
+        className="w-full rounded-lg bg-primary py-3 font-semibold text-white transition hover:opacity-90 disabled:bg-gray-400"
       >
         {submitting ? submittingLabel : submitLabel}
       </button>

--- a/client/src/pages/AddTask.tsx
+++ b/client/src/pages/AddTask.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
+import { CircleCheck } from 'lucide-react'
 import { createTask } from '@/lib/tasks'
 import { TaskForm, type TaskFormValues } from '@/components/TaskForm'
 
@@ -22,9 +23,10 @@ export function AddTask() {
   if (addedTitle) {
     return (
       <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8 text-center">
-        <h1 className="text-2xl font-bold text-gray-800">Task added ✓</h1>
-        <p className="text-gray-500">
-          <span className="font-semibold">{addedTitle}</span> is in your backlog.
+        <CircleCheck className="h-12 w-12 text-success" />
+        <h1 className="text-2xl font-bold text-gray-800">Task added</h1>
+        <p className="text-muted">
+          <span className="font-semibold text-gray-700">{addedTitle}</span> is in your backlog.
         </p>
         <div className="flex flex-col gap-3">
           <button
@@ -32,13 +34,13 @@ export function AddTask() {
               setAddedTitle(null)
               setFormKey((k) => k + 1)
             }}
-            className="rounded-lg border border-gray-300 px-6 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+            className="rounded-lg bg-gray-100 px-6 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-200"
           >
             Add another
           </button>
           <Link
             to="/play"
-            className="rounded-lg bg-[#D85A30] px-6 py-3 font-semibold text-white transition hover:bg-[#c24d27]"
+            className="rounded-lg bg-primary px-6 py-3 font-semibold text-white transition hover:opacity-90"
           >
             Let&apos;s play
           </Link>
@@ -48,12 +50,12 @@ export function AddTask() {
   }
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-gray-50 p-4">
-      <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-sm">
+    <main className="flex min-h-screen items-center justify-center p-4">
+      <div className="w-full max-w-md rounded-2xl bg-surface p-6">
         <h1 className="mb-5 text-center text-2xl font-bold text-gray-800">Add a task</h1>
         <TaskForm key={formKey} submitLabel="Add task" submittingLabel="Adding…" onSubmit={onSubmit} />
         <div className="mt-4 text-center text-sm">
-          <button onClick={() => navigate(-1)} className="text-gray-500 underline hover:text-gray-700">
+          <button onClick={() => navigate(-1)} className="text-muted underline hover:text-gray-700">
             Cancel
           </button>
         </div>

--- a/client/src/pages/EditTask.tsx
+++ b/client/src/pages/EditTask.tsx
@@ -39,14 +39,14 @@ export function EditTask() {
   }
 
   if (loading) {
-    return <main className="flex min-h-screen items-center justify-center text-gray-500">Loading…</main>
+    return <main className="flex min-h-screen items-center justify-center text-muted">Loading…</main>
   }
 
   if (error || !task) {
     return (
       <main className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center">
-        <p className="text-gray-600">{error ?? 'Task not found'}</p>
-        <Link to="/dashboard" className="text-sm text-gray-500 underline hover:text-gray-700">
+        <p className="text-gray-700">{error ?? 'Task not found'}</p>
+        <Link to="/dashboard" className="text-sm text-muted underline hover:text-gray-700">
           Back to dashboard
         </Link>
       </main>
@@ -54,8 +54,8 @@ export function EditTask() {
   }
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-gray-50 p-4">
-      <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-sm">
+    <main className="flex min-h-screen items-center justify-center p-4">
+      <div className="w-full max-w-md rounded-2xl bg-surface p-6">
         <h1 className="mb-5 text-center text-2xl font-bold text-gray-800">Edit task</h1>
         <TaskForm
           initial={{
@@ -68,7 +68,7 @@ export function EditTask() {
           onSubmit={onSubmit}
         />
         <div className="mt-4 text-center text-sm">
-          <Link to="/dashboard" className="text-gray-500 underline hover:text-gray-700">
+          <Link to="/dashboard" className="text-muted underline hover:text-gray-700">
             Cancel
           </Link>
         </div>

--- a/client/src/pages/Stats.tsx
+++ b/client/src/pages/Stats.tsx
@@ -1,14 +1,15 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import { Link } from 'react-router-dom'
+import { Flame, Zap } from 'lucide-react'
 import { Mascot } from '@/components/Mascot'
 import { fetchUserStats, type UserStats } from '@/lib/points'
 
-function Tile({ label, value, hint }: { label: string; value: string; hint?: string }) {
+function Tile({ label, value, hint }: { label: string; value: string; hint?: ReactNode }) {
   return (
-    <div className="rounded-2xl border border-gray-200 bg-white p-5 text-center">
-      <div className="text-xs font-medium uppercase tracking-wide text-gray-400">{label}</div>
+    <div className="rounded-2xl bg-surface p-5 text-center">
+      <div className="text-xs font-medium uppercase tracking-wide text-muted">{label}</div>
       <div className="mt-1 text-3xl font-extrabold tabular-nums text-gray-800">{value}</div>
-      {hint && <div className="mt-0.5 text-xs text-gray-400">{hint}</div>}
+      {hint && <div className="mt-0.5 text-xs text-muted">{hint}</div>}
     </div>
   )
 }
@@ -35,13 +36,13 @@ export function Stats() {
   }, [])
 
   if (loading) {
-    return <main className="flex min-h-screen items-center justify-center text-gray-500">Loading…</main>
+    return <main className="flex min-h-screen items-center justify-center text-muted">Loading…</main>
   }
   if (error || !stats) {
     return (
       <main className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center">
-        <p className="text-gray-600">{error ?? 'No stats yet'}</p>
-        <Link to="/" className="text-sm text-gray-500 underline hover:text-gray-700">
+        <p className="text-gray-700">{error ?? 'No stats yet'}</p>
+        <Link to="/" className="text-sm text-muted underline hover:text-gray-700">
           Back home
         </Link>
       </main>
@@ -57,8 +58,8 @@ export function Stats() {
         <h1 className="text-2xl font-bold text-gray-800">Your stats</h1>
       </div>
 
-      <section className="mb-4 rounded-2xl bg-gradient-to-r from-[#D85A30] to-[#e07a52] p-6 text-center text-white">
-        <div className="text-xs font-medium uppercase tracking-wide text-white/80">Total points</div>
+      <section className="mb-4 rounded-2xl bg-primary p-6 text-center text-white">
+        <div className="text-xs font-medium uppercase tracking-wide text-white">Total points</div>
         <div className="text-5xl font-extrabold tabular-nums">{total.toLocaleString()}</div>
       </section>
 
@@ -67,13 +68,27 @@ export function Stats() {
         <Tile
           label="Day streak"
           value={`${streak.currentDays}`}
-          hint={streak.currentDays === 1 ? 'day 🔥' : 'days 🔥'}
+          hint={
+            <span className="inline-flex items-center gap-1">
+              {streak.currentDays === 1 ? 'day' : 'days'}
+              <Flame className="h-3.5 w-3.5 text-warning" />
+            </span>
+          }
         />
-        <Tile label="Speed bonus" value={`+${lifetime.speedBonusTotal.toLocaleString()}`} hint="earned ⚡" />
+        <Tile
+          label="Speed bonus"
+          value={`+${lifetime.speedBonusTotal.toLocaleString()}`}
+          hint={
+            <span className="inline-flex items-center gap-1">
+              earned
+              <Zap className="h-3.5 w-3.5 text-warning" fill="currentColor" strokeWidth={0} />
+            </span>
+          }
+        />
         <Tile label="Daily bonus" value={`×${+today.currentMultiplier.toFixed(2)}`} hint="next task" />
       </div>
 
-      <p className="mt-4 text-center text-sm text-gray-500">
+      <p className="mt-4 text-center text-sm text-muted">
         Today: <span className="font-semibold text-gray-700">{today.pointsEarned}</span> pts from{' '}
         {today.tasksCompleted} {today.tasksCompleted === 1 ? 'task' : 'tasks'}
       </p>


### PR DESCRIPTION
## Summary
Batch 3 of the #94 retrofit — Forms + Stats to v2 tokens. Filled borderless inputs (primary focus ring), effort picker → tint tiles, flat form cards on cream, AddTask ✓ → Lucide CircleCheck, Stats gradient → flat solid primary + borderless tiles, 🔥/⚡ → Lucide Flame/Zap. All WCAG AA text combos verified by calculation; live headless-Chrome verified (form / success / edit / stats).

## Changes
- chore: init branch for #139
- #139 - Visual refresh v2 (B) Batch 3: retrofit Forms + Stats to tokens

Closes #139